### PR TITLE
fix(nix-build): update attic-action for Nix 2.24+ compat

### DIFF
--- a/.github/actions/nix-build/action.yml
+++ b/.github/actions/nix-build/action.yml
@@ -34,7 +34,8 @@ runs:
 
     - name: Configure Attic cache
       if: env.ATTIC_SERVER != '' && env.ATTIC_TOKEN != ''
-      uses: ryanccn/attic-action@v0
+      continue-on-error: true
+      uses: ryanccn/attic-action@v0.5.0
       with:
         endpoint: ${{ env.ATTIC_SERVER }}
         cache: ${{ env.ATTIC_CACHE }}


### PR DESCRIPTION
## Summary
- Update `ryanccn/attic-action@v0` → `@v0.5.0` — the old version uses `nix profile add` which was removed in Nix 2.24+
- Add `continue-on-error: true` so builds proceed even if Attic cache setup fails

## Context
All `Nix Build`, `Nix Deploy`, and `Flake Update` workflows in crush-dots are failing because `cachix/install-nix-action@v30` installs Nix 2.24+ where `nix profile add` no longer exists.

## Test plan
- [ ] Trigger a `Nix Build` workflow run on crush-dots after merge
- [ ] Verify the attic-action step either succeeds or gracefully continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)