### PR TITLE
[codex] TIN-62 add Greptile canary

### DIFF
--- a/.github/TIN-62_GREPTILE_CANARY.md
+++ b/.github/TIN-62_GREPTILE_CANARY.md
@@ -1,0 +1,12 @@
+# TIN-62 Greptile Canary
+
+This file exists only to create a minimal pull request that validates whether
+Greptile is actively reviewing pull requests in `tinyland-inc/ci-templates`.
+
+The canary should answer:
+
+- does a `Greptile Review` check appear on the PR
+- is the review signal useful and not excessively noisy
+- should `ci-templates` remain in the active Greptile pilot set
+
+This change does not affect runtime behavior.


### PR DESCRIPTION
## What changed

Adds a single docs-only file at `.github/TIN-62_GREPTILE_CANARY.md`.

## Why

This PR is an intentional canary for `TIN-62` to verify whether Greptile is
actively reviewing pull requests in `tinyland-inc/ci-templates`.

It should let us confirm:

- whether a `Greptile Review` check appears
- whether the review signal is useful and not excessively noisy
- whether `ci-templates` should remain in the active Greptile pilot set

## Impact

No runtime behavior changes.

## Validation

- `git diff --check`
- docs-only change in a fresh temporary checkout
