### PR TITLE
test(greptile): canary PR to verify review check integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,5 @@ TruffleHog (verified secrets) + Gitleaks detection.
 - **Self-hosted runners:** Attic and Bazel cache auto-detected via cluster DNS
 - **GitHub-hosted runners:** Pass `attic-server` input explicitly
 - **Secrets:** `ATTIC_TOKEN` for cache push operations
+
+<!-- greptile canary test — safe to close -->


### PR DESCRIPTION
Canary PR to verify Greptile review checks fire on this repo (TIN-65). Safe to close after verification.