### PR TITLE
feat(greptile): add review configuration and coding standards

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,27 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax", "style"],
+  "triggerOnUpdates": true,
+  "triggerOnDrafts": false,
+  "ignorePatterns": ".github/dependabot.yml",
+  "statusCheck": true,
+  "fixWithAI": true,
+  "shouldUpdateDescription": true,
+  "summarySection": { "included": true, "collapsible": false, "defaultOpen": true },
+  "issuesTableSection": { "included": true, "collapsible": true, "defaultOpen": true },
+  "sequenceDiagramSection": { "included": false, "collapsible": true, "defaultOpen": false },
+  "instructions": "This repo contains reusable GitHub Actions workflow templates consumed by other tinyland repos. Changes here have blast radius across the org. Review for: correct input/output definitions, pinned action versions (full SHA), no secrets leaking in logs, proper permissions blocks.",
+  "patternRepositories": [],
+  "customContext": {
+    "rules": [
+      "All third-party actions must be pinned to full commit SHA, not tags",
+      "Workflow inputs must have descriptions and type constraints",
+      "Secrets must never be echoed or logged, even in debug mode",
+      "Permissions must follow least-privilege (no contents: write unless justified)",
+      "Reusable workflows must define outputs explicitly"
+    ],
+    "files": [
+      { "path": "CLAUDE.md", "description": "Project conventions and context", "scope": ["**"] }
+    ]
+  }
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,4 @@
+[
+  { "path": "CLAUDE.md", "description": "Project conventions and context", "scope": ["**"] },
+  { "path": "README.md", "description": "Workflow usage instructions and input docs", "scope": ["**"] }
+]

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,22 @@
+# ci-templates: Repo-Specific Review Rules
+
+Inherits all rules from `_org-enforced-rules.md`.
+
+## GitHub Actions
+
+- Pin ALL third-party actions to full commit SHA (e.g., `actions/checkout@a5ac7e5...`), never floating tags.
+- Every reusable workflow must define `workflow_call` with typed `inputs` and `outputs`.
+- Use `permissions` blocks at the job level. Default to read-only; justify any write permissions in comments.
+- Never echo or log secrets, even behind `ACTIONS_STEP_DEBUG`. Use masking (`::add-mask::`) when passing values.
+- Use `timeout-minutes` on all jobs to prevent runaway billing.
+
+## Shell in Workflows
+
+- Inline shell steps must use `shell: bash` explicitly (not rely on runner default).
+- Use `set -euo pipefail` in multi-line run blocks.
+- Quote all variable expansions to prevent word splitting.
+
+## Blast Radius
+
+- Changes to reusable workflows affect all downstream consumers. PR descriptions must list which repos consume the changed workflow.
+- Breaking changes to workflow inputs/outputs require a deprecation period or version bump.


### PR DESCRIPTION
Adds .greptile/ configuration folder with:
- config.json: review behavior, CI/CD-focused settings
- rules.md: action pinning, permissions, reusable workflow standards
- files.json: reference to CLAUDE.md for context

Part of Greptile Phase 1 rollout (TIN-58).