### PR TITLE
[codex] add shared Bazel JS package workflow

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -1,0 +1,293 @@
+name: JS Bazel Package
+
+on:
+  workflow_call:
+    inputs:
+      node_versions:
+        description: "JSON array of Node.js versions to validate"
+        type: string
+        default: '["20", "22"]'
+      publish_node_version:
+        description: "Node.js version used for publish and dry-run steps"
+        type: string
+        default: "22"
+      pnpm_version:
+        description: "pnpm version to install"
+        type: string
+        default: "9"
+      metadata_check_command:
+        description: "Optional release metadata parity command"
+        type: string
+        default: ""
+      lint_command:
+        description: "Optional lint command"
+        type: string
+        default: ""
+      typecheck_command:
+        description: "Optional typecheck command"
+        type: string
+        default: ""
+      unit_test_command:
+        description: "Optional unit test command"
+        type: string
+        default: ""
+      integration_test_command:
+        description: "Optional integration test command"
+        type: string
+        default: ""
+      build_command:
+        description: "Build command for the workspace artifact"
+        type: string
+        default: "pnpm build"
+      package_check_command:
+        description: "Optional package surface validation command"
+        type: string
+        default: "pnpm check:package"
+      bazel_targets:
+        description: "Space-delimited Bazel targets to validate"
+        type: string
+        default: "//:pkg"
+      package_dir:
+        description: "Directory containing the Bazel-built publishable package"
+        type: string
+        default: "./bazel-bin/pkg"
+      npm_access:
+        description: "npm access mode"
+        type: string
+        default: "public"
+      npm_registry_url:
+        description: "npm registry URL for publication"
+        type: string
+        default: "https://registry.npmjs.org"
+      github_package_name:
+        description: "Optional full package name to use for GitHub Packages dry-runs/publication"
+        type: string
+        default: ""
+      github_package_registry:
+        description: "GitHub Packages registry URL"
+        type: string
+        default: "https://npm.pkg.github.com"
+      dry_run:
+        description: "When true, publish jobs only perform dry-runs"
+        type: boolean
+        default: true
+    secrets:
+      NPM_TOKEN:
+        description: "npmjs.com publish token"
+        required: false
+
+  push:
+    tags:
+      - "v*"
+
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "When true, publish jobs only perform dry-runs"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ${{ fromJson(inputs.node_versions || '["20", "22"]') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ inputs.pnpm_version || '9' }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            pnpm install --frozen-lockfile
+          else
+            pnpm install --no-frozen-lockfile
+          fi
+
+      - name: Verify release metadata
+        if: ${{ inputs.metadata_check_command != '' }}
+        run: ${{ inputs.metadata_check_command }}
+
+      - name: Lint
+        if: ${{ inputs.lint_command != '' }}
+        run: ${{ inputs.lint_command }}
+
+      - name: Typecheck
+        if: ${{ inputs.typecheck_command != '' }}
+        run: ${{ inputs.typecheck_command }}
+
+      - name: Unit tests
+        if: ${{ inputs.unit_test_command != '' }}
+        run: ${{ inputs.unit_test_command }}
+
+      - name: Integration tests
+        if: ${{ inputs.integration_test_command != '' }}
+        run: ${{ inputs.integration_test_command }}
+
+      - name: Build workspace artifact
+        run: ${{ inputs.build_command || 'pnpm build' }}
+
+      - name: Validate package surface
+        if: ${{ inputs.package_check_command != '' }}
+        run: ${{ inputs.package_check_command }}
+
+      - name: Validate Bazel targets
+        run: npx --yes @bazel/bazelisk build ${{ inputs.bazel_targets || '//:pkg' }} --verbose_failures
+
+      - name: Validate npm tarball from Bazel artifact
+        run: npm pack --dry-run ${{ inputs.package_dir || './bazel-bin/pkg' }}
+
+      - name: Validate npm publish dry-run from Bazel artifact
+        run: npm publish --dry-run --ignore-scripts --access ${{ inputs.npm_access || 'public' }} ${{ inputs.package_dir || './bazel-bin/pkg' }}
+
+      - name: Validate GitHub Packages dry-run from Bazel artifact
+        if: ${{ inputs.github_package_name != '' }}
+        shell: bash
+        run: |
+          rm -rf pkg-github
+          cp -R "${{ inputs.package_dir || './bazel-bin/pkg' }}" pkg-github
+          chmod -R u+w pkg-github
+          node -e "
+            const fs = require('fs');
+            const path = './pkg-github/package.json';
+            const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+            pkg.name = '${{ inputs.github_package_name }}';
+            pkg.publishConfig = { ...(pkg.publishConfig || {}), registry: '${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}' };
+            fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+          "
+          npm publish ./pkg-github --dry-run --ignore-scripts
+
+      - name: Archive Bazel package artifact
+        shell: bash
+        run: |
+          PACKAGE_DIR="${{ inputs.package_dir || './bazel-bin/pkg' }}"
+          PACKAGE_PARENT=$(dirname "$PACKAGE_DIR")
+          PACKAGE_BASENAME=$(basename "$PACKAGE_DIR")
+          tar -czf bazel-pkg.tgz -C "$PACKAGE_PARENT" "$PACKAGE_BASENAME"
+
+      - name: Upload Bazel package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bazel-pkg
+          path: bazel-pkg.tgz
+          if-no-files-found: error
+
+  publish-npm:
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.publish_node_version || '22' }}
+          registry-url: ${{ inputs.npm_registry_url || 'https://registry.npmjs.org' }}
+
+      - name: Download Bazel package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: bazel-pkg
+
+      - name: Extract Bazel package artifact
+        run: tar -xzf bazel-pkg.tgz
+
+      - name: Normalize Bazel package permissions
+        shell: bash
+        run: chmod -R u+w "./$(basename "${{ inputs.package_dir || './bazel-bin/pkg' }}")"
+
+      - name: Publish or dry-run npm artifact
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          PACKAGE_BASENAME=$(basename "${{ inputs.package_dir || './bazel-bin/pkg' }}")
+
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            DRY_RUN=false
+          elif [ "${{ inputs.dry_run }}" = "false" ]; then
+            DRY_RUN=false
+          else
+            DRY_RUN=true
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            npm publish "./$PACKAGE_BASENAME" --dry-run --ignore-scripts --access ${{ inputs.npm_access || 'public' }}
+          else
+            npm publish "./$PACKAGE_BASENAME" --ignore-scripts --access ${{ inputs.npm_access || 'public' }} --provenance
+          fi
+
+  publish-github:
+    needs: validate
+    if: ${{ inputs.github_package_name != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.publish_node_version || '22' }}
+          registry-url: ${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}
+
+      - name: Download Bazel package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: bazel-pkg
+
+      - name: Extract Bazel package artifact
+        run: tar -xzf bazel-pkg.tgz
+
+      - name: Prepare GitHub Packages publish directory
+        shell: bash
+        run: |
+          PACKAGE_BASENAME=$(basename "${{ inputs.package_dir || './bazel-bin/pkg' }}")
+          rm -rf pkg-github
+          cp -R "./$PACKAGE_BASENAME" pkg-github
+          chmod -R u+w pkg-github
+          node -e "
+            const fs = require('fs');
+            const path = './pkg-github/package.json';
+            const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+            pkg.name = '${{ inputs.github_package_name }}';
+            pkg.publishConfig = { ...(pkg.publishConfig || {}), registry: '${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}' };
+            fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Publish or dry-run GitHub Packages artifact
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            DRY_RUN=false
+          elif [ "${{ inputs.dry_run }}" = "false" ]; then
+            DRY_RUN=false
+          else
+            DRY_RUN=true
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            npm publish ./pkg-github --dry-run --ignore-scripts
+          else
+            npm publish ./pkg-github --ignore-scripts
+          fi

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -2,6 +2,7 @@ name: JS Bazel Package
 
 on:
   workflow_call:
+    outputs: {}
     inputs:
       runner_labels_json:
         description: "JSON array of runner labels to use for all jobs"
@@ -100,12 +101,12 @@ on:
         description: "npmjs.com publish token"
         required: false
 
-permissions:
-  contents: read
-
 jobs:
   validate:
     runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -141,10 +142,13 @@ jobs:
           cache: pnpm
 
       - name: Enable Corepack
+        shell: bash
         run: corepack enable
 
       - name: Install dependencies
+        shell: bash
         run: |
+          set -euo pipefail
           if [ -f pnpm-lock.yaml ]; then
             pnpm install --frozen-lockfile
           else
@@ -153,44 +157,55 @@ jobs:
 
       - name: Prepare workspace
         if: ${{ inputs.prepare_command != '' }}
+        shell: bash
         run: ${{ inputs.prepare_command }}
 
       - name: Verify release metadata
         if: ${{ inputs.metadata_check_command != '' }}
+        shell: bash
         run: ${{ inputs.metadata_check_command }}
 
       - name: Lint
         if: ${{ inputs.lint_command != '' }}
         continue-on-error: ${{ inputs.lint_continue_on_error }}
+        shell: bash
         run: ${{ inputs.lint_command }}
 
       - name: Typecheck
         if: ${{ inputs.typecheck_command != '' }}
         continue-on-error: ${{ inputs.typecheck_continue_on_error }}
+        shell: bash
         run: ${{ inputs.typecheck_command }}
 
       - name: Unit tests
         if: ${{ inputs.unit_test_command != '' }}
+        shell: bash
         run: ${{ inputs.unit_test_command }}
 
       - name: Integration tests
         if: ${{ inputs.integration_test_command != '' }}
+        shell: bash
         run: ${{ inputs.integration_test_command }}
 
       - name: Build workspace artifact
+        shell: bash
         run: ${{ inputs.build_command || 'pnpm build' }}
 
       - name: Validate package surface
         if: ${{ inputs.package_check_command != '' }}
+        shell: bash
         run: ${{ inputs.package_check_command }}
 
       - name: Validate Bazel targets
+        shell: bash
         run: npx --yes @bazel/bazelisk build ${{ inputs.bazel_targets || '//:pkg' }} --verbose_failures
 
       - name: Validate npm tarball from Bazel artifact
+        shell: bash
         run: npm pack --dry-run ${{ inputs.package_dir || './bazel-bin/pkg' }}
 
       - name: Validate npm publish dry-run from Bazel artifact
+        shell: bash
         run: npm publish --dry-run --ignore-scripts --access ${{ inputs.npm_access || 'public' }} ${{ inputs.package_dir || './bazel-bin/pkg' }}
 
       - name: Validate GitHub Packages dry-run from Bazel artifact
@@ -220,6 +235,7 @@ jobs:
       - name: Archive Bazel package artifact
         shell: bash
         run: |
+          set -euo pipefail
           PACKAGE_DIR="${{ inputs.package_dir || './bazel-bin/pkg' }}"
           PACKAGE_PARENT=$(dirname "$PACKAGE_DIR")
           PACKAGE_BASENAME=$(basename "$PACKAGE_DIR")
@@ -237,6 +253,7 @@ jobs:
     needs: validate
     if: ${{ inputs.dry_run == false }}
     runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    timeout-minutes: 20
     permissions:
       contents: read
       id-token: write
@@ -268,6 +285,7 @@ jobs:
           name: bazel-pkg
 
       - name: Extract Bazel package artifact
+        shell: bash
         run: tar -xzf bazel-pkg.tgz
 
       - name: Normalize Bazel package permissions
@@ -280,6 +298,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
+          set -euo pipefail
           PACKAGE_BASENAME=$(basename "${{ inputs.package_dir || './bazel-bin/pkg' }}")
           PUBLISH_ARGS=("./$PACKAGE_BASENAME" --ignore-scripts --access "${{ inputs.npm_access || 'public' }}")
           if [ "${{ inputs.npm_publish_provenance }}" = "true" ] && [ "$RUNNER_ENVIRONMENT" != "self-hosted" ]; then
@@ -291,6 +310,7 @@ jobs:
     needs: validate
     if: ${{ inputs.github_package_name != '' && inputs.dry_run == false }}
     runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write
@@ -322,6 +342,7 @@ jobs:
           name: bazel-pkg
 
       - name: Extract Bazel package artifact
+        shell: bash
         run: tar -xzf bazel-pkg.tgz
 
       - name: Prepare GitHub Packages publish directory

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -3,6 +3,10 @@ name: JS Bazel Package
 on:
   workflow_call:
     inputs:
+      runner_labels_json:
+        description: "JSON array of runner labels to use for all jobs"
+        type: string
+        default: '["ubuntu-latest"]'
       node_versions:
         description: "JSON array of Node.js versions to validate"
         type: string
@@ -17,6 +21,14 @@ on:
         default: "9"
       metadata_check_command:
         description: "Optional release metadata parity command"
+        type: string
+        default: ""
+      cleanup_paths:
+        description: "Optional space-delimited paths to chmod/rm before install or publish extraction"
+        type: string
+        default: "dist node_modules bazel-bin bazel-out bazel-testlogs .pnpm-store pkg pkg-github bazel-pkg.tgz MODULE.bazel.lock"
+      prepare_command:
+        description: "Optional workspace preparation command after install"
         type: string
         default: ""
       lint_command:
@@ -55,6 +67,10 @@ on:
         description: "npm access mode"
         type: string
         default: "public"
+      npm_publish_provenance:
+        description: "When true, request npm provenance for npmjs publishes when supported"
+        type: boolean
+        default: true
       npm_registry_url:
         description: "npm registry URL for publication"
         type: string
@@ -83,19 +99,30 @@ permissions:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
     strategy:
       fail-fast: false
       matrix:
         node-version: ${{ fromJson(inputs.node_versions || '["20", "22"]') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          clean: false
+
+      - name: Clean stale workspace artifacts
+        if: ${{ inputs.cleanup_paths != '' }}
+        shell: bash
+        run: |
+          for path in ${{ inputs.cleanup_paths }}; do
+            chmod -R u+w "$path" 2>/dev/null || true
+          done
+          rm -rf ${{ inputs.cleanup_paths }}
 
       - uses: pnpm/action-setup@v4
         with:
           version: ${{ inputs.pnpm_version || '9' }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -110,6 +137,10 @@ jobs:
           else
             pnpm install --no-frozen-lockfile
           fi
+
+      - name: Prepare workspace
+        if: ${{ inputs.prepare_command != '' }}
+        run: ${{ inputs.prepare_command }}
 
       - name: Verify release metadata
         if: ${{ inputs.metadata_check_command != '' }}
@@ -182,15 +213,24 @@ jobs:
   publish-npm:
     needs: validate
     if: ${{ inputs.dry_run == false }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.publish_node_version || '22' }}
           registry-url: ${{ inputs.npm_registry_url || 'https://registry.npmjs.org' }}
+
+      - name: Clean stale publish artifacts
+        if: ${{ inputs.cleanup_paths != '' }}
+        shell: bash
+        run: |
+          for path in ${{ inputs.cleanup_paths }}; do
+            chmod -R u+w "$path" 2>/dev/null || true
+          done
+          rm -rf ${{ inputs.cleanup_paths }}
 
       - name: Download Bazel package artifact
         uses: actions/download-artifact@v4
@@ -208,22 +248,36 @@ jobs:
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           PACKAGE_BASENAME=$(basename "${{ inputs.package_dir || './bazel-bin/pkg' }}")
-          npm publish "./$PACKAGE_BASENAME" --ignore-scripts --access ${{ inputs.npm_access || 'public' }} --provenance
+          PUBLISH_ARGS=("./$PACKAGE_BASENAME" --ignore-scripts --access "${{ inputs.npm_access || 'public' }}")
+          if [ "${{ inputs.npm_publish_provenance }}" = "true" ] && [ "$RUNNER_ENVIRONMENT" != "self-hosted" ]; then
+            PUBLISH_ARGS+=(--provenance)
+          fi
+          npm publish "${PUBLISH_ARGS[@]}"
 
   publish-github:
     needs: validate
     if: ${{ inputs.github_package_name != '' && inputs.dry_run == false }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.publish_node_version || '22' }}
           registry-url: ${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}
+
+      - name: Clean stale publish artifacts
+        if: ${{ inputs.cleanup_paths != '' }}
+        shell: bash
+        run: |
+          for path in ${{ inputs.cleanup_paths }}; do
+            chmod -R u+w "$path" 2>/dev/null || true
+          done
+          rm -rf ${{ inputs.cleanup_paths }}
 
       - name: Download Bazel package artifact
         uses: actions/download-artifact@v4
@@ -253,4 +307,4 @@ jobs:
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm publish ./pkg-github --ignore-scripts
+        run: npm publish ./pkg-github --access ${{ inputs.npm_access || 'public' }} --ignore-scripts

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -35,10 +35,18 @@ on:
         description: "Optional lint command"
         type: string
         default: ""
+      lint_continue_on_error:
+        description: "When true, lint failures are reported but do not fail validation"
+        type: boolean
+        default: false
       typecheck_command:
         description: "Optional typecheck command"
         type: string
         default: ""
+      typecheck_continue_on_error:
+        description: "When true, typecheck failures are reported but do not fail validation"
+        type: boolean
+        default: false
       unit_test_command:
         description: "Optional unit test command"
         type: string
@@ -148,10 +156,12 @@ jobs:
 
       - name: Lint
         if: ${{ inputs.lint_command != '' }}
+        continue-on-error: ${{ inputs.lint_continue_on_error }}
         run: ${{ inputs.lint_command }}
 
       - name: Typecheck
         if: ${{ inputs.typecheck_command != '' }}
+        continue-on-error: ${{ inputs.typecheck_continue_on_error }}
         run: ${{ inputs.typecheck_command }}
 
       - name: Unit tests

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -202,11 +202,16 @@ jobs:
 
       - name: Validate npm tarball from Bazel artifact
         shell: bash
-        run: npm pack --dry-run ${{ inputs.package_dir || './bazel-bin/pkg' }}
+        env:
+          PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
+        run: npm pack --dry-run "$PACKAGE_DIR"
 
       - name: Validate npm publish dry-run from Bazel artifact
         shell: bash
-        run: npm publish --dry-run --ignore-scripts --access ${{ inputs.npm_access || 'public' }} ${{ inputs.package_dir || './bazel-bin/pkg' }}
+        env:
+          NPM_ACCESS: ${{ inputs.npm_access || 'public' }}
+          PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
+        run: npm publish --dry-run --ignore-scripts --access "$NPM_ACCESS" "$PACKAGE_DIR"
 
       - name: Validate GitHub Packages dry-run from Bazel artifact
         if: ${{ inputs.github_package_name != '' }}
@@ -214,10 +219,11 @@ jobs:
         env:
           GITHUB_PACKAGE_NAME: ${{ inputs.github_package_name }}
           GITHUB_PACKAGE_REGISTRY: ${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}
+          PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
         run: |
           set -euo pipefail
           rm -rf pkg-github
-          cp -R "${{ inputs.package_dir || './bazel-bin/pkg' }}" pkg-github
+          cp -R "$PACKAGE_DIR" pkg-github
           chmod -R u+w pkg-github
           node - <<'NODE'
           const fs = require('fs');
@@ -234,9 +240,10 @@ jobs:
 
       - name: Archive Bazel package artifact
         shell: bash
+        env:
+          PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
         run: |
           set -euo pipefail
-          PACKAGE_DIR="${{ inputs.package_dir || './bazel-bin/pkg' }}"
           PACKAGE_PARENT=$(dirname "$PACKAGE_DIR")
           PACKAGE_BASENAME=$(basename "$PACKAGE_DIR")
           tar -czf bazel-pkg.tgz -C "$PACKAGE_PARENT" "$PACKAGE_BASENAME"
@@ -290,17 +297,21 @@ jobs:
 
       - name: Normalize Bazel package permissions
         shell: bash
-        run: chmod -R u+w "./$(basename "${{ inputs.package_dir || './bazel-bin/pkg' }}")"
+        env:
+          PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
+        run: chmod -R u+w "./$(basename "$PACKAGE_DIR")"
 
       - name: Publish or dry-run npm artifact
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_ACCESS: ${{ inputs.npm_access || 'public' }}
+          PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
           RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           set -euo pipefail
-          PACKAGE_BASENAME=$(basename "${{ inputs.package_dir || './bazel-bin/pkg' }}")
-          PUBLISH_ARGS=("./$PACKAGE_BASENAME" --ignore-scripts --access "${{ inputs.npm_access || 'public' }}")
+          PACKAGE_BASENAME=$(basename "$PACKAGE_DIR")
+          PUBLISH_ARGS=("./$PACKAGE_BASENAME" --ignore-scripts --access "$NPM_ACCESS")
           if [ "${{ inputs.npm_publish_provenance }}" = "true" ] && [ "$RUNNER_ENVIRONMENT" != "self-hosted" ]; then
             PUBLISH_ARGS+=(--provenance)
           fi
@@ -350,9 +361,10 @@ jobs:
         env:
           GITHUB_PACKAGE_NAME: ${{ inputs.github_package_name }}
           GITHUB_PACKAGE_REGISTRY: ${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}
+          PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
         run: |
           set -euo pipefail
-          PACKAGE_BASENAME=$(basename "${{ inputs.package_dir || './bazel-bin/pkg' }}")
+          PACKAGE_BASENAME=$(basename "$PACKAGE_DIR")
           rm -rf pkg-github
           cp -R "./$PACKAGE_BASENAME" pkg-github
           chmod -R u+w pkg-github

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -198,7 +198,9 @@ jobs:
 
       - name: Validate Bazel targets
         shell: bash
-        run: npx --yes @bazel/bazelisk build ${{ inputs.bazel_targets || '//:pkg' }} --verbose_failures
+        env:
+          BAZEL_TARGETS: ${{ inputs.bazel_targets || '//:pkg' }}
+        run: npx --yes @bazel/bazelisk build $BAZEL_TARGETS --verbose_failures
 
       - name: Validate npm tarball from Bazel artifact
         shell: bash
@@ -384,4 +386,5 @@ jobs:
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm publish ./pkg-github --access ${{ inputs.npm_access || 'public' }} --ignore-scripts
+          NPM_ACCESS: ${{ inputs.npm_access || 'public' }}
+        run: npm publish ./pkg-github --access "$NPM_ACCESS" --ignore-scripts

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -226,6 +226,7 @@ jobs:
           tar -czf bazel-pkg.tgz -C "$PACKAGE_PARENT" "$PACKAGE_BASENAME"
 
       - name: Upload Bazel package artifact
+        if: ${{ matrix.node-version == (inputs.publish_node_version || '22') }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bazel-pkg

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -102,8 +102,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
-  id-token: write
 
 jobs:
   validate:
@@ -113,7 +111,7 @@ jobs:
       matrix:
         node-version: ${{ fromJson(inputs.node_versions || '["20", "22"]') }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           clean: false
 
@@ -121,16 +119,23 @@ jobs:
         if: ${{ inputs.cleanup_paths != '' }}
         shell: bash
         run: |
+          set -euo pipefail
           for path in ${{ inputs.cleanup_paths }}; do
-            chmod -R u+w "$path" 2>/dev/null || true
+            case "$path" in
+              ""|/*|*..*|-*)
+                echo "Refusing unsafe cleanup path: $path" >&2
+                exit 1
+                ;;
+            esac
+            chmod -R u+w -- "$path" 2>/dev/null || true
+            rm -rf -- "$path"
           done
-          rm -rf ${{ inputs.cleanup_paths }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: ${{ inputs.pnpm_version || '9' }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -191,18 +196,25 @@ jobs:
       - name: Validate GitHub Packages dry-run from Bazel artifact
         if: ${{ inputs.github_package_name != '' }}
         shell: bash
+        env:
+          GITHUB_PACKAGE_NAME: ${{ inputs.github_package_name }}
+          GITHUB_PACKAGE_REGISTRY: ${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}
         run: |
+          set -euo pipefail
           rm -rf pkg-github
           cp -R "${{ inputs.package_dir || './bazel-bin/pkg' }}" pkg-github
           chmod -R u+w pkg-github
-          node -e "
-            const fs = require('fs');
-            const path = './pkg-github/package.json';
-            const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
-            pkg.name = '${{ inputs.github_package_name }}';
-            pkg.publishConfig = { ...(pkg.publishConfig || {}), registry: '${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}' };
-            fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
-          "
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = './pkg-github/package.json';
+          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+          pkg.name = process.env.GITHUB_PACKAGE_NAME;
+          pkg.publishConfig = {
+            ...(pkg.publishConfig || {}),
+            registry: process.env.GITHUB_PACKAGE_REGISTRY
+          };
+          fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+          NODE
           npm publish ./pkg-github --dry-run --ignore-scripts
 
       - name: Archive Bazel package artifact
@@ -214,7 +226,7 @@ jobs:
           tar -czf bazel-pkg.tgz -C "$PACKAGE_PARENT" "$PACKAGE_BASENAME"
 
       - name: Upload Bazel package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bazel-pkg
           path: bazel-pkg.tgz
@@ -228,7 +240,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ inputs.publish_node_version || '22' }}
           registry-url: ${{ inputs.npm_registry_url || 'https://registry.npmjs.org' }}
@@ -237,13 +249,20 @@ jobs:
         if: ${{ inputs.cleanup_paths != '' }}
         shell: bash
         run: |
+          set -euo pipefail
           for path in ${{ inputs.cleanup_paths }}; do
-            chmod -R u+w "$path" 2>/dev/null || true
+            case "$path" in
+              ""|/*|*..*|-*)
+                echo "Refusing unsafe cleanup path: $path" >&2
+                exit 1
+                ;;
+            esac
+            chmod -R u+w -- "$path" 2>/dev/null || true
+            rm -rf -- "$path"
           done
-          rm -rf ${{ inputs.cleanup_paths }}
 
       - name: Download Bazel package artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: bazel-pkg
 
@@ -275,7 +294,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ inputs.publish_node_version || '22' }}
           registry-url: ${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}
@@ -284,13 +303,20 @@ jobs:
         if: ${{ inputs.cleanup_paths != '' }}
         shell: bash
         run: |
+          set -euo pipefail
           for path in ${{ inputs.cleanup_paths }}; do
-            chmod -R u+w "$path" 2>/dev/null || true
+            case "$path" in
+              ""|/*|*..*|-*)
+                echo "Refusing unsafe cleanup path: $path" >&2
+                exit 1
+                ;;
+            esac
+            chmod -R u+w -- "$path" 2>/dev/null || true
+            rm -rf -- "$path"
           done
-          rm -rf ${{ inputs.cleanup_paths }}
 
       - name: Download Bazel package artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: bazel-pkg
 
@@ -299,19 +325,26 @@ jobs:
 
       - name: Prepare GitHub Packages publish directory
         shell: bash
+        env:
+          GITHUB_PACKAGE_NAME: ${{ inputs.github_package_name }}
+          GITHUB_PACKAGE_REGISTRY: ${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}
         run: |
+          set -euo pipefail
           PACKAGE_BASENAME=$(basename "${{ inputs.package_dir || './bazel-bin/pkg' }}")
           rm -rf pkg-github
           cp -R "./$PACKAGE_BASENAME" pkg-github
           chmod -R u+w pkg-github
-          node -e "
-            const fs = require('fs');
-            const path = './pkg-github/package.json';
-            const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
-            pkg.name = '${{ inputs.github_package_name }}';
-            pkg.publishConfig = { ...(pkg.publishConfig || {}), registry: '${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}' };
-            fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
-          "
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = './pkg-github/package.json';
+          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+          pkg.name = process.env.GITHUB_PACKAGE_NAME;
+          pkg.publishConfig = {
+            ...(pkg.publishConfig || {}),
+            registry: process.env.GITHUB_PACKAGE_REGISTRY
+          };
+          fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+          NODE
 
       - name: Publish or dry-run GitHub Packages artifact
         shell: bash

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -76,18 +76,6 @@ on:
         description: "npmjs.com publish token"
         required: false
 
-  push:
-    tags:
-      - "v*"
-
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "When true, publish jobs only perform dry-runs"
-        required: false
-        type: boolean
-        default: true
-
 permissions:
   contents: read
   packages: write
@@ -193,6 +181,7 @@ jobs:
 
   publish-npm:
     needs: validate
+    if: ${{ inputs.dry_run == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -221,24 +210,11 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           PACKAGE_BASENAME=$(basename "${{ inputs.package_dir || './bazel-bin/pkg' }}")
-
-          if [ "$GITHUB_EVENT_NAME" = "push" ] && [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            DRY_RUN=false
-          elif [ "${{ inputs.dry_run }}" = "false" ]; then
-            DRY_RUN=false
-          else
-            DRY_RUN=true
-          fi
-
-          if [ "$DRY_RUN" = "true" ]; then
-            npm publish "./$PACKAGE_BASENAME" --dry-run --ignore-scripts --access ${{ inputs.npm_access || 'public' }}
-          else
-            npm publish "./$PACKAGE_BASENAME" --ignore-scripts --access ${{ inputs.npm_access || 'public' }} --provenance
-          fi
+          npm publish "./$PACKAGE_BASENAME" --ignore-scripts --access ${{ inputs.npm_access || 'public' }} --provenance
 
   publish-github:
     needs: validate
-    if: ${{ inputs.github_package_name != '' }}
+    if: ${{ inputs.github_package_name != '' && inputs.dry_run == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -277,17 +253,4 @@ jobs:
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "$GITHUB_EVENT_NAME" = "push" ] && [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            DRY_RUN=false
-          elif [ "${{ inputs.dry_run }}" = "false" ]; then
-            DRY_RUN=false
-          else
-            DRY_RUN=true
-          fi
-
-          if [ "$DRY_RUN" = "true" ]; then
-            npm publish ./pkg-github --dry-run --ignore-scripts
-          else
-            npm publish ./pkg-github --ignore-scripts
-          fi
+        run: npm publish ./pkg-github --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ TruffleHog (verified secrets) + Gitleaks detection.
 
 Reusable workflow for JS/TS packages whose release artifact is built by Bazel and then published to npm or GitHub Packages.
 
+Supports self-hosted runner labels, stale workspace cleanup, optional prepare steps like `svelte-kit sync`, Bazel-artifact dry-runs, and npm/GitHub Packages publication from the extracted Bazel package.
+
 See [docs/js-bazel-package.md](./docs/js-bazel-package.md) for usage and inputs.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ TruffleHog (verified secrets) + Gitleaks detection.
 
 Reusable workflow for JS/TS packages whose release artifact is built by Bazel and then published to npm or GitHub Packages.
 
-Supports self-hosted runner labels, stale workspace cleanup, optional prepare steps like `svelte-kit sync`, Bazel-artifact dry-runs, and npm/GitHub Packages publication from the extracted Bazel package.
+Supports self-hosted runner labels, stale workspace cleanup, optional prepare steps like `svelte-kit sync`, optional advisory lint/typecheck lanes, Bazel-artifact dry-runs, and npm/GitHub Packages publication from the extracted Bazel package.
 
 See [docs/js-bazel-package.md](./docs/js-bazel-package.md) for usage and inputs.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ TruffleHog (verified secrets) + Gitleaks detection.
 - uses: tinyland-inc/ci-templates/.github/actions/secrets-scan@main
 ```
 
+## Reusable Workflows
+
+### `js-bazel-package`
+
+Reusable workflow for JS/TS packages whose release artifact is built by Bazel and then published to npm or GitHub Packages.
+
+See [docs/js-bazel-package.md](./docs/js-bazel-package.md) for usage and inputs.
+
 ## Requirements
 
 - **Self-hosted runners:** Attic and Bazel cache auto-detected via cluster DNS

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -11,12 +11,15 @@ It is meant for packages like:
 ## What it does
 
 - installs the workspace with pnpm
+- optionally cleans stale self-hosted workspace artifacts before install or publish extraction
+- optionally runs a repo-specific prepare step after install
 - runs optional metadata, lint, typecheck, unit, and integration commands
 - builds the workspace artifact
 - validates the Bazel-built package via `npm pack --dry-run`
 - validates npm publish dry-runs against the Bazel artifact
 - optionally validates GitHub Packages dry-runs after rewriting package metadata
 - uploads the Bazel-built package artifact for publish jobs
+- preserves npm provenance on GitHub-hosted runners while skipping it on self-hosted runners when needed
 
 ## Example
 
@@ -34,6 +37,9 @@ jobs:
   package:
     uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@main
     with:
+      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
+      cleanup_paths: "pkg pkg-github dist node_modules .svelte-kit bazel-bin bazel-out bazel-testlogs .pnpm-store bazel-pkg.tgz MODULE.bazel.lock"
+      prepare_command: pnpm exec svelte-kit sync
       metadata_check_command: pnpm check:release-metadata
       lint_command: pnpm lint
       typecheck_command: pnpm check
@@ -50,6 +56,10 @@ jobs:
 
 ## Notes
 
+- `runner_labels_json` lets callers preserve self-hosted runner routing instead of hard-coding `ubuntu-latest` into each package repo.
+- `cleanup_paths` is useful on long-lived self-hosted runners where stale `dist/`, Bazel outputs, or old package artifacts can poison later runs.
+- `prepare_command` is where SvelteKit callers should run `pnpm exec svelte-kit sync` before typecheck or build.
 - `bazel_targets` is space-delimited so callers can validate `//:pkg` alone or include extra targets like `//:typecheck` and `//:test`.
 - `package_dir` should point at the Bazel-built publishable package directory, not the workspace root.
 - `github_package_name` is optional. Leave it empty to skip GitHub Packages dry-runs and publish steps.
+- npmjs publication uses `--provenance` by default, but the reusable workflow will skip it automatically on self-hosted runners.

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -1,0 +1,55 @@
+# JS Bazel Package Workflow
+
+`js-bazel-package.yml` is the reusable workflow for JavaScript/TypeScript packages whose authoritative publish artifact is built by Bazel rather than published directly from the workspace tree.
+
+It is meant for packages like:
+
+- `@tummycrypt/scheduling-kit`
+- `@tummycrypt/tinyvectors`
+- `@tummycrypt/scheduling-bridge`
+
+## What it does
+
+- installs the workspace with pnpm
+- runs optional metadata, lint, typecheck, unit, and integration commands
+- builds the workspace artifact
+- validates the Bazel-built package via `npm pack --dry-run`
+- validates npm publish dry-runs against the Bazel artifact
+- optionally validates GitHub Packages dry-runs after rewriting package metadata
+- uploads the Bazel-built package artifact for publish jobs
+
+## Example
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  package:
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@main
+    with:
+      metadata_check_command: pnpm check:release-metadata
+      lint_command: pnpm lint
+      typecheck_command: pnpm check
+      unit_test_command: pnpm test:unit
+      integration_test_command: pnpm test:integration
+      build_command: pnpm build
+      package_check_command: pnpm check:package
+      bazel_targets: "//:typecheck //:pkg //:test"
+      package_dir: ./bazel-bin/pkg
+      github_package_name: "@jesssullivan/scheduling-kit"
+      dry_run: true
+    secrets: inherit
+```
+
+## Notes
+
+- `bazel_targets` is space-delimited so callers can validate `//:pkg` alone or include extra targets like `//:typecheck` and `//:test`.
+- `package_dir` should point at the Bazel-built publishable package directory, not the workspace root.
+- `github_package_name` is optional. Leave it empty to skip GitHub Packages dry-runs and publish steps.

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -42,7 +42,9 @@ jobs:
       prepare_command: pnpm exec svelte-kit sync
       metadata_check_command: pnpm check:release-metadata
       lint_command: pnpm lint
+      lint_continue_on_error: false
       typecheck_command: pnpm check
+      typecheck_continue_on_error: false
       unit_test_command: pnpm test:unit
       integration_test_command: pnpm test:integration
       build_command: pnpm build
@@ -59,6 +61,7 @@ jobs:
 - `runner_labels_json` lets callers preserve self-hosted runner routing instead of hard-coding `ubuntu-latest` into each package repo.
 - `cleanup_paths` is useful on long-lived self-hosted runners where stale `dist/`, Bazel outputs, or old package artifacts can poison later runs.
 - `prepare_command` is where SvelteKit callers should run `pnpm exec svelte-kit sync` before typecheck or build.
+- `lint_continue_on_error` and `typecheck_continue_on_error` are there for transitional repos whose warning/debt lanes should stay visible without becoming blocking yet.
 - `bazel_targets` is space-delimited so callers can validate `//:pkg` alone or include extra targets like `//:typecheck` and `//:test`.
 - `package_dir` should point at the Bazel-built publishable package directory, not the workspace root.
 - `github_package_name` is optional. Leave it empty to skip GitHub Packages dry-runs and publish steps.


### PR DESCRIPTION
## Summary

- add a reusable Bazel-backed JS package workflow for package repos
- harden it for self-hosted runners with cleanup, runner-label, and prepare-step inputs
- support advisory lint and typecheck lanes for transitional downstream repos

## Why

The package repos were carrying near-duplicate CI and publish logic around the same authority contract. This moves that contract into one reusable workflow without flattening the repo-specific differences that still matter.

## Validation

- parsed `.github/workflows/js-bazel-package.yml`
- reviewed the shared workflow docs and caller surface

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new reusable Bazel-backed JS package workflow that consolidates CI/publish logic shared across tinyland package repos. All concerns raised in the previous review round have been addressed: actions are pinned to full commit SHAs, permissions are scoped per-job, `outputs: {}` is declared, shell steps have `shell: bash` and `set -euo pipefail`, `cleanup_paths` is validated with a safe case statement, sensitive inputs are routed through `env:` blocks and heredocs, and the artifact upload is correctly gated on the publish node version to prevent collision.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all prior P0/P1 findings are resolved; only two minor P2 style inconsistencies remain.

Every substantive concern from the previous review (SHA pinning, permissions scope, secret injection via Node.js inline, artifact name collision, shell hardening) has been properly addressed. The two remaining findings are P2: one env-var consistency nit on `npm_publish_provenance` and one floating `@main` ref in the docs example. Neither blocks correctness or security.

No files require special attention beyond the two P2 nits noted inline.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | New reusable workflow; previous P0/P1 concerns (SHA pinning, permissions scope, secret injection, artifact collision, shell hardening) are all addressed — one minor P2 inconsistency remains where `npm_publish_provenance` is inlined in the shell rather than routed through `env:`. |
| docs/js-bazel-package.md | New docs page; accurate and thorough, but the caller example uses a floating `@main` ref that contradicts the team's SHA-pinning rule. |
| README.md | Adds a short entry for the new `js-bazel-package` workflow with a pointer to the docs; no issues. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 317

Comment:
**`npm_publish_provenance` not passed through an env var**

Every other input used inside a multi-line `run:` block in this workflow is routed through an `env:` entry to keep the shell source clean. `${{ inputs.npm_publish_provenance }}` is the one exception — it's still inlined directly. While the `boolean` type constraint limits the value to `true`/`false` (so there's no injection risk), passing it via `env:` would be consistent with the rest of the workflow and makes the provenance gate easier to audit.

```suggestion
          if [ "$NPM_PUBLISH_PROVENANCE" = "true" ] && [ "$RUNNER_ENVIRONMENT" != "self-hosted" ]; then
```

Add `NPM_PUBLISH_PROVENANCE: ${{ inputs.npm_publish_provenance }}` to the `env:` block above.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/js-bazel-package.md
Line: 38

Comment:
**Example caller uses a floating `@main` ref**

The example shows callers referencing `js-bazel-package.yml@main`, which contradicts the team's own rule to pin all action references to a full commit SHA. Downstream repos reading this doc are likely to copy the pattern as-is. Consider updating the example to use a pinned SHA (with a `# vX` comment), or add a note reminding callers to substitute the SHA for their own lockstep pinning.

```suggestion
    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@<commit-sha>  # vX
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (7): Last reviewed commit: ["fix: sanitize remaining shared workflow ..."](https://github.com/tinyland-inc/ci-templates/commit/dde8c378815e47aa027c163278430c0d98ae007b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28702921)</sub>

<!-- /greptile_comment -->