### PR TITLE
[codex] Make JS Bazel package contract explicit

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -4,10 +4,26 @@ on:
   workflow_call:
     outputs: {}
     inputs:
+      runner_mode:
+        description: "Runner policy for validate and same-runner publish jobs: compat, hosted, shared, or repo_owned"
+        type: string
+        default: "compat"
+      shared_runner_labels_json:
+        description: "JSON array of shared GloriousFlywheel runner labels used when runner_mode=shared"
+        type: string
+        default: '["tinyland-docker"]'
       runner_labels_json:
-        description: "JSON array of runner labels to use for all jobs"
+        description: "JSON array of runner labels used by compat mode and required when runner_mode=repo_owned"
         type: string
         default: '["ubuntu-latest"]'
+      workspace_mode:
+        description: "Workspace policy for validation: isolated or persistent_compat"
+        type: string
+        default: "persistent_compat"
+      publish_mode:
+        description: "Publish policy: same_runner or hosted_exception"
+        type: string
+        default: "same_runner"
       node_versions:
         description: "JSON array of Node.js versions to validate"
         type: string
@@ -25,7 +41,7 @@ on:
         type: string
         default: ""
       cleanup_paths:
-        description: "Optional space-delimited paths to chmod/rm before install or publish extraction"
+        description: "Optional space-delimited paths to chmod/rm before install when workspace_mode=persistent_compat"
         type: string
         default: "dist node_modules bazel-bin bazel-out bazel-testlogs .pnpm-store pkg pkg-github bazel-pkg.tgz MODULE.bazel.lock"
       prepare_command:
@@ -103,7 +119,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(inputs.runner_mode == 'repo_owned' && inputs.runner_labels_json || inputs.runner_mode == 'shared' && inputs.shared_runner_labels_json || inputs.runner_mode == 'hosted' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -112,15 +128,63 @@ jobs:
       matrix:
         node-version: ${{ fromJson(inputs.node_versions || '["20", "22"]') }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          clean: false
-
-      - name: Clean stale workspace artifacts
-        if: ${{ inputs.cleanup_paths != '' }}
+      - name: Validate workflow contract
         shell: bash
         run: |
           set -euo pipefail
+          case "${{ inputs.runner_mode }}" in
+            compat|hosted|shared|repo_owned) ;;
+            *)
+              echo "Unsupported runner_mode: ${{ inputs.runner_mode }}" >&2
+              exit 1
+              ;;
+          esac
+          case "${{ inputs.workspace_mode }}" in
+            isolated|persistent_compat) ;;
+            *)
+              echo "Unsupported workspace_mode: ${{ inputs.workspace_mode }}" >&2
+              exit 1
+              ;;
+          esac
+          case "${{ inputs.publish_mode }}" in
+            same_runner|hosted_exception) ;;
+            *)
+              echo "Unsupported publish_mode: ${{ inputs.publish_mode }}" >&2
+              exit 1
+              ;;
+          esac
+          if [ "${{ inputs.runner_mode }}" = "repo_owned" ] && [ "${{ inputs.runner_labels_json }}" = '["ubuntu-latest"]' ]; then
+            echo "runner_mode=repo_owned requires explicit runner_labels_json" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          clean: ${{ inputs.workspace_mode != 'persistent_compat' }}
+
+      - name: Configure self-hosted cache contract
+        if: ${{ runner.environment != 'github-hosted' }}
+        uses: tinyland-inc/ci-templates/.github/actions/nix-setup@main
+
+      - name: Resolve working directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          WORKSPACE_DIR="$GITHUB_WORKSPACE"
+          if [ "${{ inputs.workspace_mode }}" = "isolated" ]; then
+            WORKSPACE_DIR="$RUNNER_TEMP/js-bazel-package-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${{ matrix.node-version }}"
+            rm -rf "$WORKSPACE_DIR"
+            mkdir -p "$WORKSPACE_DIR"
+            cp -a "$GITHUB_WORKSPACE"/. "$WORKSPACE_DIR"
+          fi
+          echo "WORKSPACE_DIR=$WORKSPACE_DIR" >> "$GITHUB_ENV"
+
+      - name: Clean stale workspace artifacts
+        if: ${{ inputs.workspace_mode == 'persistent_compat' && inputs.cleanup_paths != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
           for path in ${{ inputs.cleanup_paths }}; do
             case "$path" in
               ""|/*|*..*|-*)
@@ -140,6 +204,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            **/pnpm-lock.yaml
 
       - name: Enable Corepack
         shell: bash
@@ -149,6 +216,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          cd "$WORKSPACE_DIR"
           if [ -f pnpm-lock.yaml ]; then
             pnpm install --frozen-lockfile
           else
@@ -158,62 +226,95 @@ jobs:
       - name: Prepare workspace
         if: ${{ inputs.prepare_command != '' }}
         shell: bash
-        run: ${{ inputs.prepare_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+          ${{ inputs.prepare_command }}
 
       - name: Verify release metadata
         if: ${{ inputs.metadata_check_command != '' }}
         shell: bash
-        run: ${{ inputs.metadata_check_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+          ${{ inputs.metadata_check_command }}
 
       - name: Lint
         if: ${{ inputs.lint_command != '' }}
         continue-on-error: ${{ inputs.lint_continue_on_error }}
         shell: bash
-        run: ${{ inputs.lint_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+          ${{ inputs.lint_command }}
 
       - name: Typecheck
         if: ${{ inputs.typecheck_command != '' }}
         continue-on-error: ${{ inputs.typecheck_continue_on_error }}
         shell: bash
-        run: ${{ inputs.typecheck_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+          ${{ inputs.typecheck_command }}
 
       - name: Unit tests
         if: ${{ inputs.unit_test_command != '' }}
         shell: bash
-        run: ${{ inputs.unit_test_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+          ${{ inputs.unit_test_command }}
 
       - name: Integration tests
         if: ${{ inputs.integration_test_command != '' }}
         shell: bash
-        run: ${{ inputs.integration_test_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+          ${{ inputs.integration_test_command }}
 
       - name: Build workspace artifact
         shell: bash
-        run: ${{ inputs.build_command || 'pnpm build' }}
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+          ${{ inputs.build_command || 'pnpm build' }}
 
       - name: Validate package surface
         if: ${{ inputs.package_check_command != '' }}
         shell: bash
-        run: ${{ inputs.package_check_command }}
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+          ${{ inputs.package_check_command }}
 
       - name: Validate Bazel targets
         shell: bash
         env:
           BAZEL_TARGETS: ${{ inputs.bazel_targets || '//:pkg' }}
-        run: npx --yes @bazel/bazelisk build $BAZEL_TARGETS --verbose_failures
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+          npx --yes @bazel/bazelisk build $BAZEL_TARGETS --verbose_failures
 
       - name: Validate npm tarball from Bazel artifact
         shell: bash
         env:
           PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
-        run: npm pack --dry-run "$PACKAGE_DIR"
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+          npm pack --dry-run "$PACKAGE_DIR"
 
       - name: Validate npm publish dry-run from Bazel artifact
         shell: bash
         env:
           NPM_ACCESS: ${{ inputs.npm_access || 'public' }}
           PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
-        run: npm publish --dry-run --ignore-scripts --access "$NPM_ACCESS" "$PACKAGE_DIR"
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+          npm publish --dry-run --ignore-scripts --access "$NPM_ACCESS" "$PACKAGE_DIR"
 
       - name: Validate GitHub Packages dry-run from Bazel artifact
         if: ${{ inputs.github_package_name != '' }}
@@ -224,6 +325,7 @@ jobs:
           PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
         run: |
           set -euo pipefail
+          cd "$WORKSPACE_DIR"
           rm -rf pkg-github
           cp -R "$PACKAGE_DIR" pkg-github
           chmod -R u+w pkg-github
@@ -246,6 +348,7 @@ jobs:
           PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
         run: |
           set -euo pipefail
+          cd "$WORKSPACE_DIR"
           PACKAGE_PARENT=$(dirname "$PACKAGE_DIR")
           PACKAGE_BASENAME=$(basename "$PACKAGE_DIR")
           tar -czf bazel-pkg.tgz -C "$PACKAGE_PARENT" "$PACKAGE_BASENAME"
@@ -255,55 +358,55 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bazel-pkg
-          path: bazel-pkg.tgz
+          path: ${{ env.WORKSPACE_DIR }}/bazel-pkg.tgz
           if-no-files-found: error
 
   publish-npm:
     needs: validate
     if: ${{ inputs.dry_run == false }}
-    runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_mode == 'repo_owned' && inputs.runner_labels_json || inputs.runner_mode == 'shared' && inputs.shared_runner_labels_json || inputs.runner_mode == 'hosted' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     permissions:
       contents: read
       id-token: write
     steps:
+      - name: Validate publish contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ inputs.publish_mode }}" in
+            same_runner|hosted_exception) ;;
+            *)
+              echo "Unsupported publish_mode: ${{ inputs.publish_mode }}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Configure self-hosted cache contract
+        if: ${{ runner.environment != 'github-hosted' }}
+        uses: tinyland-inc/ci-templates/.github/actions/nix-setup@main
+
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ inputs.publish_node_version || '22' }}
           registry-url: ${{ inputs.npm_registry_url || 'https://registry.npmjs.org' }}
-
-      - name: Clean stale publish artifacts
-        if: ${{ inputs.cleanup_paths != '' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          for path in ${{ inputs.cleanup_paths }}; do
-            case "$path" in
-              ""|/*|*..*|-*)
-                echo "Refusing unsafe cleanup path: $path" >&2
-                exit 1
-                ;;
-            esac
-            chmod -R u+w -- "$path" 2>/dev/null || true
-            rm -rf -- "$path"
-          done
 
       - name: Download Bazel package artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: bazel-pkg
 
-      - name: Extract Bazel package artifact
+      - name: Extract Bazel package artifact into isolated publish workspace
         shell: bash
-        run: tar -xzf bazel-pkg.tgz
+        run: |
+          set -euo pipefail
+          PUBLISH_ROOT="$RUNNER_TEMP/js-bazel-package-publish-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}"
+          rm -rf "$PUBLISH_ROOT"
+          mkdir -p "$PUBLISH_ROOT"
+          tar -xzf bazel-pkg.tgz -C "$PUBLISH_ROOT"
+          echo "PUBLISH_ROOT=$PUBLISH_ROOT" >> "$GITHUB_ENV"
 
-      - name: Normalize Bazel package permissions
-        shell: bash
-        env:
-          PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
-        run: chmod -R u+w "./$(basename "$PACKAGE_DIR")"
-
-      - name: Publish or dry-run npm artifact
+      - name: Publish npm artifact
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -313,7 +416,7 @@ jobs:
         run: |
           set -euo pipefail
           PACKAGE_BASENAME=$(basename "$PACKAGE_DIR")
-          PUBLISH_ARGS=("./$PACKAGE_BASENAME" --ignore-scripts --access "$NPM_ACCESS")
+          PUBLISH_ARGS=("$PUBLISH_ROOT/$PACKAGE_BASENAME" --ignore-scripts --access "$NPM_ACCESS")
           if [ "${{ inputs.npm_publish_provenance }}" = "true" ] && [ "$RUNNER_ENVIRONMENT" != "self-hosted" ]; then
             PUBLISH_ARGS+=(--provenance)
           fi
@@ -322,41 +425,47 @@ jobs:
   publish-github:
     needs: validate
     if: ${{ inputs.github_package_name != '' && inputs.dry_run == false }}
-    runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_mode == 'repo_owned' && inputs.runner_labels_json || inputs.runner_mode == 'shared' && inputs.shared_runner_labels_json || inputs.runner_mode == 'hosted' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     permissions:
       contents: read
       packages: write
     steps:
+      - name: Validate publish contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ inputs.publish_mode }}" in
+            same_runner|hosted_exception) ;;
+            *)
+              echo "Unsupported publish_mode: ${{ inputs.publish_mode }}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Configure self-hosted cache contract
+        if: ${{ runner.environment != 'github-hosted' }}
+        uses: tinyland-inc/ci-templates/.github/actions/nix-setup@main
+
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ inputs.publish_node_version || '22' }}
           registry-url: ${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}
-
-      - name: Clean stale publish artifacts
-        if: ${{ inputs.cleanup_paths != '' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          for path in ${{ inputs.cleanup_paths }}; do
-            case "$path" in
-              ""|/*|*..*|-*)
-                echo "Refusing unsafe cleanup path: $path" >&2
-                exit 1
-                ;;
-            esac
-            chmod -R u+w -- "$path" 2>/dev/null || true
-            rm -rf -- "$path"
-          done
 
       - name: Download Bazel package artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: bazel-pkg
 
-      - name: Extract Bazel package artifact
+      - name: Extract Bazel package artifact into isolated publish workspace
         shell: bash
-        run: tar -xzf bazel-pkg.tgz
+        run: |
+          set -euo pipefail
+          PUBLISH_ROOT="$RUNNER_TEMP/js-bazel-package-publish-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}"
+          rm -rf "$PUBLISH_ROOT"
+          mkdir -p "$PUBLISH_ROOT"
+          tar -xzf bazel-pkg.tgz -C "$PUBLISH_ROOT"
+          echo "PUBLISH_ROOT=$PUBLISH_ROOT" >> "$GITHUB_ENV"
 
       - name: Prepare GitHub Packages publish directory
         shell: bash
@@ -367,12 +476,12 @@ jobs:
         run: |
           set -euo pipefail
           PACKAGE_BASENAME=$(basename "$PACKAGE_DIR")
-          rm -rf pkg-github
-          cp -R "./$PACKAGE_BASENAME" pkg-github
-          chmod -R u+w pkg-github
+          rm -rf "$PUBLISH_ROOT/pkg-github"
+          cp -R "$PUBLISH_ROOT/$PACKAGE_BASENAME" "$PUBLISH_ROOT/pkg-github"
+          chmod -R u+w "$PUBLISH_ROOT/pkg-github"
           node - <<'NODE'
           const fs = require('fs');
-          const path = './pkg-github/package.json';
+          const path = process.env.PUBLISH_ROOT + '/pkg-github/package.json';
           const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
           pkg.name = process.env.GITHUB_PACKAGE_NAME;
           pkg.publishConfig = {
@@ -382,9 +491,9 @@ jobs:
           fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
           NODE
 
-      - name: Publish or dry-run GitHub Packages artifact
+      - name: Publish GitHub Packages artifact
         shell: bash
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ github.token }}
           NPM_ACCESS: ${{ inputs.npm_access || 'public' }}
-        run: npm publish ./pkg-github --access "$NPM_ACCESS" --ignore-scripts
+        run: npm publish "$PUBLISH_ROOT/pkg-github" --access "$NPM_ACCESS" --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ TruffleHog (verified secrets) + Gitleaks detection.
 
 Reusable workflow for JS/TS packages whose release artifact is built by Bazel and then published to npm or GitHub Packages.
 
-Supports self-hosted runner labels, stale workspace cleanup, optional prepare steps like `svelte-kit sync`, optional advisory lint/typecheck lanes, Bazel-artifact dry-runs, and npm/GitHub Packages publication from the extracted Bazel package.
+Supports explicit runner policy (`compat`, `hosted`, `shared`, `repo_owned`), explicit workspace policy (`isolated`, `persistent_compat`), explicit publish policy (`same_runner`, `hosted_exception`), self-hosted cache contract wiring, optional advisory lint/typecheck lanes, Bazel-artifact dry-runs, and npm/GitHub Packages publication from the extracted Bazel package.
 
 See [docs/js-bazel-package.md](./docs/js-bazel-package.md) for usage and inputs.
 

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -1,6 +1,8 @@
 # JS Bazel Package Workflow
 
-`js-bazel-package.yml` is the reusable workflow for JavaScript/TypeScript packages whose authoritative publish artifact is built by Bazel rather than published directly from the workspace tree.
+`js-bazel-package.yml` is the reusable workflow for JavaScript and TypeScript
+packages whose authoritative publish artifact is built by Bazel rather than
+published directly from the workspace tree.
 
 It is meant for packages like:
 
@@ -10,18 +12,76 @@ It is meant for packages like:
 
 ## What it does
 
+- makes runner intent explicit with `runner_mode`
+- makes workspace hygiene explicit with `workspace_mode`
+- makes publish authority explicit with `publish_mode`
 - installs the workspace with pnpm
-- optionally cleans stale self-hosted workspace artifacts before install or publish extraction
-- optionally runs a repo-specific prepare step after install
+- configures Attic and Bazel cache hints on self-hosted runners
+- optionally keeps legacy cleanup-based workspace behavior for migration
+- optionally stages validation work in an isolated scratch workspace
 - runs optional metadata, lint, typecheck, unit, and integration commands
 - builds the workspace artifact
 - validates the Bazel-built package via `npm pack --dry-run`
 - validates npm publish dry-runs against the Bazel artifact
 - optionally validates GitHub Packages dry-runs after rewriting package metadata
 - uploads the Bazel-built package artifact for publish jobs
-- preserves npm provenance on GitHub-hosted runners while skipping it on self-hosted runners when needed
+- publishes from the same runner class or from an explicit hosted exception path
 
-## Example
+## Contract inputs
+
+### `runner_mode`
+
+Allowed values:
+
+- `compat`
+- `hosted`
+- `shared`
+- `repo_owned`
+
+Meaning:
+
+- `compat`
+  - preserve the legacy `runner_labels_json` behavior
+  - use this only as a migration bridge
+- `hosted`
+  - validate and publish on GitHub-hosted runners intentionally
+- `shared`
+  - validate and publish on a documented shared GloriousFlywheel lane
+- `repo_owned`
+  - validate and publish on repo-specific runner labels
+
+### `workspace_mode`
+
+Allowed values:
+
+- `isolated`
+- `persistent_compat`
+
+Meaning:
+
+- `isolated`
+  - checkout normally
+  - copy the repo into a per-job scratch directory under `$RUNNER_TEMP`
+  - run validation there
+- `persistent_compat`
+  - keep the old cleanup-based model for long-lived self-hosted workspaces
+
+### `publish_mode`
+
+Allowed values:
+
+- `same_runner`
+- `hosted_exception`
+
+Meaning:
+
+- `same_runner`
+  - publish from the same runner class that validated the Bazel artifact
+- `hosted_exception`
+  - validate on the chosen runner class
+  - publish from `ubuntu-latest` intentionally after artifact handoff
+
+## Example: repo-owned self-hosted package path
 
 ```yaml
 name: CI
@@ -37,14 +97,14 @@ jobs:
   package:
     uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@main
     with:
-      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
-      cleanup_paths: "pkg pkg-github dist node_modules .svelte-kit bazel-bin bazel-out bazel-testlogs .pnpm-store bazel-pkg.tgz MODULE.bazel.lock"
+      runner_mode: repo_owned
+      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
+      workspace_mode: isolated
+      publish_mode: same_runner
       prepare_command: pnpm exec svelte-kit sync
       metadata_check_command: pnpm check:release-metadata
       lint_command: pnpm lint
-      lint_continue_on_error: false
       typecheck_command: pnpm check
-      typecheck_continue_on_error: false
       unit_test_command: pnpm test:unit
       integration_test_command: pnpm test:integration
       build_command: pnpm build
@@ -56,13 +116,38 @@ jobs:
     secrets: inherit
 ```
 
+## Example: hosted template consumer
+
+```yaml
+jobs:
+  package:
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@main
+    with:
+      runner_mode: hosted
+      workspace_mode: isolated
+      publish_mode: hosted_exception
+      lint_command: pnpm lint
+      typecheck_command: pnpm typecheck
+      unit_test_command: pnpm test
+      build_command: pnpm build
+      bazel_targets: "//:pkg"
+      package_dir: ./bazel-bin/pkg
+      dry_run: true
+```
+
 ## Notes
 
-- `runner_labels_json` lets callers preserve self-hosted runner routing instead of hard-coding `ubuntu-latest` into each package repo.
-- `cleanup_paths` is useful on long-lived self-hosted runners where stale `dist/`, Bazel outputs, or old package artifacts can poison later runs.
-- `prepare_command` is where SvelteKit callers should run `pnpm exec svelte-kit sync` before typecheck or build.
-- `lint_continue_on_error` and `typecheck_continue_on_error` are there for transitional repos whose warning/debt lanes should stay visible without becoming blocking yet.
-- `bazel_targets` is space-delimited so callers can validate `//:pkg` alone or include extra targets like `//:typecheck` and `//:test`.
-- `package_dir` should point at the Bazel-built publishable package directory, not the workspace root.
-- `github_package_name` is optional. Leave it empty to skip GitHub Packages dry-runs and publish steps.
-- npmjs publication uses `--provenance` by default, but the reusable workflow will skip it automatically on self-hosted runners.
+- `compat` exists only to let existing consumers adopt the new template without
+  breaking in one PR.
+- `runner_mode=repo_owned` should always pass explicit `runner_labels_json`.
+- `runner_mode=shared` uses `shared_runner_labels_json`, which defaults to
+  `["tinyland-docker"]`.
+- self-hosted jobs now call `nix-setup`, so Attic and Bazel cache hints are
+  explicit instead of incidental runner state.
+- `workspace_mode=isolated` is the preferred contract for downstream pilots.
+- `cleanup_paths` is still available, but only applies to
+  `workspace_mode=persistent_compat`.
+- publish jobs always extract into an isolated temp directory, even when the
+  validation workspace stays in compatibility mode.
+- npmjs publication still requests provenance on hosted runners and skips it on
+  self-hosted runners when needed.


### PR DESCRIPTION
## What changed
- added explicit `runner_mode`, `workspace_mode`, and `publish_mode` inputs to `js-bazel-package.yml`
- preserved a temporary `compat` path so existing consumers can migrate without breaking in one step
- wired self-hosted jobs through `nix-setup` so Attic and Bazel cache hints are explicit
- added isolated validation workspaces and isolated publish extraction
- updated the reusable workflow docs and README to describe the new contract

## Why
The previous shared workflow hid the actual platform policy. A repo could consume the template while still silently falling back to hosted runners, persistent workspace cleanup, and coupled publish behavior. That made adoption reporting weak and made downstream pilots harder to reason about.

## Impact
- downstream repos can now declare whether they are hosted, shared self-hosted, or repo-owned
- workspace isolation is available as a first-class contract instead of bespoke cleanup logic
- hosted publish can be modeled as an explicit exception instead of incidental behavior

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/js-bazel-package.yml")'`

## Notes
- this is the Phase A compatibility version of V2, not the final tightening pass
- follow-on pilots point `scheduling-kit` and `acuity-middleware` at repo-owned isolated lanes and mark `tinyvectors` explicitly hosted

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `js-bazel-package.yml` from an implicit shared workflow into an explicit contract with `runner_mode`, `workspace_mode`, and `publish_mode` inputs, adds isolated validation workspaces, and wires self-hosted jobs through `nix-setup`. The compat defaults preserve backward compatibility for existing consumers.

- **P1 — upload-artifact will 403 on every run:** The `validate` job declares `permissions: contents: read` only. `actions/upload-artifact@v4` requires `actions: write` on the job token; without it the artifact upload step fails and neither publish job ever gets an artifact to download. Add `actions: write` to the `validate` permissions block (and verify `actions: read` for the download steps in the two publish jobs).
- The PR description notes `scheduling-kit`, `acuity-middleware`, and `tinyvectors` as follow-on pilots but does not clarify whether any repos currently consume `js-bazel-package.yml`. The blast-radius rule requires PR descriptions to list current consumers; if there are none yet, a note to that effect satisfies the rule.

<h3>Confidence Score: 4/5</h3>

Not safe to merge as-is — the missing `actions: write` permission will cause every run to fail at the artifact upload step.

One clear P1 defect: the validate job's restrictive permissions block breaks actions/upload-artifact@v4, making the publish path dead on arrival. All other findings are P2 style or hardening concerns. Score is 4 rather than lower because the fix is a single-line addition and the rest of the workflow logic is sound.

`.github/workflows/js-bazel-package.yml` — specifically the `validate` job `permissions` block (line 124) and the matching download-artifact permissions in the two publish jobs.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Major rewrite adding explicit runner/workspace/publish mode contracts; `validate` job's `permissions: contents: read` is missing `actions: write` required by upload-artifact@v4, which will cause every publish run to fail. Also three floating `@main` refs on `nix-setup` and two permission blocks missing justification comments. |
| docs/js-bazel-package.md | New documentation accurately describes all new contract inputs, examples, and migration notes; no issues found. |
| README.md | Updated to reflect new workflow capabilities; no issues found. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 124-125

Comment:
**Missing `actions: write` for upload-artifact**

`actions/upload-artifact@v4` requires `actions: write` on the job token — confirmed in the v4 changelog and by multiple reports. With only `contents: read` the upload step at line 358 will fail with a 403 when the job tries to store the `bazel-pkg` artifact, so every publish run will never have an artifact to download.

```suggestion
    permissions:
      contents: read
      actions: write  # required by actions/upload-artifact@v4
```

The two publish jobs' `download-artifact` steps may also need `actions: read` added for the same reason — worth verifying against the v4 docs before merging.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 167

Comment:
**Floating `@main` ref on first-party action**

`tinyland-inc/ci-templates/.github/actions/nix-setup@main` is a mutable reference. If a downstream consumer pins the *calling* workflow to a specific commit SHA or tag (a common hardening practice), the `nix-setup@main` step inside still resolves to whatever HEAD of `main` is at run-time — not the version that was current when the consumer pinned. A breaking change to `nix-setup` will silently affect pinned consumers. The same pattern appears in `publish-npm` (line 387) and `publish-github` (line 447).

Per the repo's review instructions, action version pins should be full SHAs. Suggest replacing all three occurrences with the commit SHA of the current `nix-setup` action.

```suggestion
        uses: tinyland-inc/ci-templates/.github/actions/nix-setup@<COMMIT_SHA> # main
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 369-372

Comment:
**Write permissions lack required justification comments**

The review rules require write permissions to be justified with inline comments. `id-token: write` is needed for npm provenance attestation; `packages: write` (line 431) is needed to push to GitHub Packages. Neither permission block has a comment explaining why.

```suggestion
    permissions:
      contents: read
      id-token: write  # required for npm provenance attestation (OIDC)
```

Similarly for `publish-github` (around line 431):
```yaml
    permissions:
      contents: read
      packages: write  # required to publish to GitHub Packages registry
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 188

Comment:
**`cleanup_paths` interpolated directly into shell without env-var indirection**

`${{ inputs.cleanup_paths }}` is substituted literally into the bash source before the shell sees it. A caller passing a value containing shell metacharacters (e.g. `$(...)` or backtick sequences) would execute arbitrary commands. Even though `workflow_call` callers are trusted, passing the value through an environment variable is a standard hardening practice for any string-typed input that isn't a deliberate command.

```suggestion
        env:
          CLEANUP_PATHS: ${{ inputs.cleanup_paths }}
        run: |
          set -euo pipefail
          cd "$WORKSPACE_DIR"
          read -ra _paths <<< "$CLEANUP_PATHS"
          for path in "${_paths[@]}"; do
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: make js bazel package contract exp..."](https://github.com/tinyland-inc/ci-templates/commit/86f2229f58ad3dab43327a92839f9e0827491521) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28811808)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->