### PR TITLE
[codex] docs: document npm publish workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ Supports explicit runner policy (`compat`, `hosted`, `shared`, `repo_owned`), ex
 
 See [docs/js-bazel-package.md](./docs/js-bazel-package.md) for usage and inputs.
 
+### `npm-publish`
+
+Reusable workflow for straightforward Node package build, test, and publish
+flows that publish directly from the workspace tree.
+
+Current behavior:
+
+- hosted-only on `ubuntu-latest`
+- build and advisory test on a Node version matrix
+- publish to GitHub Packages and npmjs on tags
+
+See [docs/npm-publish.md](./docs/npm-publish.md) for usage and inputs.
+
 ## Requirements
 
 - **Self-hosted runners:** Attic and Bazel cache auto-detected via cluster DNS

--- a/docs/npm-publish.md
+++ b/docs/npm-publish.md
@@ -1,0 +1,98 @@
+# NPM Publish Workflow
+
+`npm-publish.yml` is the reusable workflow for straightforward Node package
+build, test, and publish flows that publish directly from the workspace tree.
+
+Unlike `js-bazel-package.yml`, this workflow is currently GitHub-hosted only.
+It does not expose shared-runner or repo-owned runner modes.
+
+## What it does
+
+- validates the package on a matrix of Node versions
+- installs dependencies with pnpm
+- runs `pnpm build`
+- runs `pnpm test` when a `test` script exists, but does not fail the workflow
+  if tests fail
+- verifies that `npm pack --dry-run` does not include source maps
+- publishes to GitHub Packages on tags
+- publishes to npmjs with provenance on tags
+
+## Contract inputs
+
+### `node-versions`
+
+JSON array of Node versions used in the build and test matrix.
+
+Default:
+
+- `["20", "22"]`
+
+### `publish-node-version`
+
+Node version used by the publish jobs.
+
+Default:
+
+- `"22"`
+
+### `pnpm-version`
+
+pnpm version to install.
+
+Default:
+
+- `"9"`
+
+### `registry-url`
+
+npm registry URL used by the npm publish job.
+
+Default:
+
+- `"https://registry.npmjs.org"`
+
+## Secrets
+
+### `NPM_TOKEN`
+
+Optional npmjs publish token used by the npm publish job.
+
+GitHub Packages publish uses the built-in `GITHUB_TOKEN`.
+
+## Execution model
+
+Current jobs:
+
+- `build-and-test`
+- `publish-gpr`
+- `publish-npm`
+
+All three jobs currently run on:
+
+- `ubuntu-latest`
+
+This is a hosted-only workflow today.
+
+## Example
+
+```yaml
+jobs:
+  publish:
+    uses: tinyland-inc/ci-templates/.github/workflows/npm-publish.yml@main
+    with:
+      node-versions: '["20", "22"]'
+      publish-node-version: "22"
+      pnpm-version: "9"
+      registry-url: "https://registry.npmjs.org"
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+## Notes
+
+- This workflow publishes from the workspace tree, not from a Bazel-built
+  extracted artifact.
+- Tests are advisory today: the workflow warns if `pnpm test` fails but
+  continues.
+- If a package needs explicit runner policy, isolated workspaces, or publish
+  authority control, use `js-bazel-package.yml` instead.


### PR DESCRIPTION
## What changed

This documents the second reusable workflow in `ci-templates`.

It adds:
- `docs/npm-publish.md`
- a matching `README.md` section for `npm-publish`

## Why it changed

The repo README only described `js-bazel-package`, even though `npm-publish.yml` is also a live reusable workflow on `main`.

That made the docs disagree with the actual workflow surface and obscured that `npm-publish.yml` is currently hosted-only.

## Impact

Consumers now have a direct doc page for `npm-publish.yml`, including:
- what it does
- its inputs and secret contract
- its hosted-only execution model
- when to use it instead of `js-bazel-package.yml`

## Validation

- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Docs-only PR adding `docs/npm-publish.md` and a `README.md` section for the `npm-publish.yml` reusable workflow. The documentation is largely accurate — inputs, defaults, execution model, and job names all match the workflow source — with one inaccuracy in the secret contract description noted inline.

<h3>Confidence Score: 5/5</h3>

Safe to merge; docs-only change with one minor documentation accuracy issue.

All findings are P2. The NPM_TOKEN "Optional" framing is a doc clarification, not a runtime regression — the workflow behavior itself is unchanged by this PR.

docs/npm-publish.md — NPM_TOKEN secret description should clarify that omitting it causes publish-npm to fail on tag pushes.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/npm-publish.md | New docs page for npm-publish.yml; accurately describes inputs, execution model, and jobs. One inaccuracy: NPM_TOKEN is described as "Optional" but the publish-npm job has no guard to skip on missing token, causing hard failures on tag pushes. |
| README.md | Adds npm-publish section to Reusable Workflows; accurately summarizes the workflow and links to the new docs page. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/npm-publish.md
Line: 57-61

Comment:
**`NPM_TOKEN` "Optional" is misleading**

The secret is declared `required: false` in the workflow, but the `publish-npm` job runs unconditionally on any `v*` tag push with no `if: secrets.NPM_TOKEN != ''` guard. If a consumer omits the token, `NODE_AUTH_TOKEN` is set to an empty string and `pnpm publish` fails with an auth error on every tag push. The doc's "Optional" framing implies a graceful no-op, but the actual behavior is a hard failure.

Consider adding a note that omitting `NPM_TOKEN` causes `publish-npm` to fail on tags, and that consumers who only want GitHub Packages publishing need to suppress or skip that job separately.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document npm publish workflow"](https://github.com/tinyland-inc/ci-templates/commit/fc204016637f5feb1259b7264a90e6e73dfc8c6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28849420)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->