### PR TITLE
fix(runs-on): simplify runner label expression to fix startup_failure

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -119,7 +119,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ${{ fromJson(inputs.runner_mode == 'repo_owned' && inputs.runner_labels_json || inputs.runner_mode == 'shared' && inputs.shared_runner_labels_json || inputs.runner_mode == 'hosted' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -364,7 +364,7 @@ jobs:
   publish-npm:
     needs: validate
     if: ${{ inputs.dry_run == false }}
-    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_mode == 'repo_owned' && inputs.runner_labels_json || inputs.runner_mode == 'shared' && inputs.shared_runner_labels_json || inputs.runner_mode == 'hosted' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -425,7 +425,7 @@ jobs:
   publish-github:
     needs: validate
     if: ${{ inputs.github_package_name != '' && inputs.dry_run == false }}
-    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_mode == 'repo_owned' && inputs.runner_labels_json || inputs.runner_mode == 'shared' && inputs.shared_runner_labels_json || inputs.runner_mode == 'hosted' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Simplifies `runs-on` expressions in all 3 jobs (validate, publish-npm, publish-github) to fix `startup_failure` on every caller since PR #7
- The complex chained `&&`/`||` expression in `runs-on` caused GitHub Actions to fail before creating any jobs — 0 jobs, no logs, instant `startup_failure`
- Reverts to the proven pattern from before PR #7: `fromJson(inputs.runner_labels_json || '["ubuntu-latest"]')`
- `runner_mode` contract enforcement remains in the step-level validation (unchanged)
- Publish jobs retain `hosted_exception` override with a simpler two-term expression

## Impact

Unblocks CI for:
- `Jesssullivan/scheduling-kit` (all CI runs since #64 merged)
- `tinyland-inc/acuity-middleware` (all CI runs since #50 merged)

## Test plan

- [ ] Merge this PR
- [ ] Update callers to pin to the new SHA
- [ ] Trigger `workflow_dispatch` on scheduling-kit and acuity-middleware
- [ ] Verify jobs are created (no startup_failure) and run to completion

Closes #9

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix simplifies the `runs-on` expressions in all three jobs (`validate`, `publish-npm`, `publish-github`) to resolve `startup_failure` caused by the complex chained `&&`/`||` expression introduced in PR #7, reverting to the pre-PR #7 pattern.

- The simplified `validate` expression (`fromJson(inputs.runner_labels_json || '[\"ubuntu-latest\"]')`) silently discards `runner_mode=shared` → `shared_runner_labels_json` routing, but the step-level validation at line 136 still accepts `shared` as a valid value. Any caller using `runner_mode=shared` with a custom `shared_runner_labels_json` will run on the wrong runner with no error or log entry.

<h3>Confidence Score: 4/5</h3>

Safe to merge as an emergency hotfix, but the `runner_mode=shared` contract mismatch should be addressed in a follow-up.

One P1 finding: the step-level validation still accepts `runner_mode=shared` as valid but the simplified `runs-on` no longer honors `shared_runner_labels_json`, creating a silent wrong-runner scenario. The fix itself (removing the complex expression) is correct and necessary; the gap is an unreconciled contract rather than a new breakage introduced by this PR.

.github/workflows/js-bazel-package.yml — the `case` statement at line 136 should either drop `shared` from accepted values or a comment should clarify its routing is not implemented.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Simplifies `runs-on` expressions in all 3 jobs to fix startup_failure; silently drops `runner_mode=shared` → `shared_runner_labels_json` routing while step-level validation still accepts `shared` as valid. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 122

Comment:
**`runner_mode=shared` contract broken silently**

The simplified expression drops `shared_runner_labels_json` entirely, but the step-level validation (line 136) still accepts `shared` as a valid `runner_mode`. Any caller setting `runner_mode=shared` with a custom `shared_runner_labels_json` will silently run on `runner_labels_json` (defaulting to `["ubuntu-latest"]`) instead of their shared runner — wrong runner, no error, no log.

The same pattern affects `publish-npm` (line 367) and `publish-github` (line 428).

If `runner_mode=shared` is intentionally unsupported by this simplified expression, the step-level `case` should reject it with an explicit error, or a comment should document the missing routing so future maintainers don't re-introduce a broken expression.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(runs-on): simplify runner label expr..."](https://github.com/tinyland-inc/ci-templates/commit/a0e544c400cf5dc73cfe7e58357fffcc8cfd7c97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28858485)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->