### PR TITLE
fix(permissions): remove per-job permissions from reusable workflow

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -121,8 +121,6 @@ jobs:
   validate:
     runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 30
-    permissions:
-      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -366,9 +364,6 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 20
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - name: Validate publish contract
         shell: bash
@@ -427,9 +422,6 @@ jobs:
     if: ${{ inputs.github_package_name != '' && inputs.dry_run == false }}
     runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 20
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Validate publish contract
         shell: bash


### PR DESCRIPTION
## Summary
- Removes all 3 `permissions` blocks from `js-bazel-package.yml` (validate, publish-npm, publish-github)
- Root cause of `startup_failure` on all callers (scheduling-kit, acuity-middleware)

## Root cause
Reusable workflows **cannot expand** `GITHUB_TOKEN` permissions beyond what the caller grants. When the caller's repo default is `read` (the standard secure default), per-job blocks requesting `id-token: write` or `packages: write` cause GitHub Actions to reject the entire workflow at planning time — `startup_failure` with zero jobs created.

## Proof (binary search on test branch)
| Test | Result |
|------|--------|
| Inline job (no reusable workflow) | ✅ success |
| Minimal reusable workflow (echo) | ✅ success |
| Validate job only (no publish jobs) | ✅ failure (jobs created, expected build error) |
| Publish stubs, simple runs-on, **no permissions** | ✅ success (jobs created) |
| Publish stubs, compound runs-on, **no permissions** | ✅ failure (jobs created) |
| Publish stubs, simple runs-on, **WITH permissions** | ❌ startup_failure |
| Full workflow (compound runs-on + permissions) | ❌ startup_failure |

## Migration note
Callers that use `dry_run: false` and need npm provenance (`id-token: write`) or GitHub Packages (`packages: write`) must add those permissions to their caller workflow:

```yaml
permissions:
  contents: read
  id-token: write   # for npm provenance
  packages: write   # for GitHub Packages
```

Callers using `dry_run: true` (current state of all callers) need no changes.

Closes #9

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes three job-level `permissions` blocks from `js-bazel-package.yml` to fix a confirmed `startup_failure` affecting all callers — the blocks were requesting write permissions that exceeded caller defaults at planning time. The root cause analysis and binary-search proof in the PR description are thorough and the fix correctly unblocks current callers (all using `dry_run: true`).

- The `validate` job now has no `permissions` block, leaving it to inherit whatever the caller grants rather than being scoped to the read-only `contents: read` it actually needs. Adding `permissions: contents: read` there is safe (restrictions never cause startup_failure) and would satisfy the repo rule.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the immediate goal of unblocking callers; validate job should have an explicit read-only permissions block before this is considered complete.

One P1 finding remains: the validate job is missing a permissions block that the repo rule requires and that could be added without regression risk. All other findings are P2 style/documentation issues. P1 keeps the score at 4.

.github/workflows/js-bazel-package.yml — validate job permissions block

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Removes all three job-level `permissions` blocks (validate, publish-npm, publish-github) to fix caller `startup_failure`; validate job now inherits caller permissions instead of being scoped to read-only, violating the repo rule. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.github/workflows/js-bazel-package.yml`, line 121-127 ([link](https://github.com/tinyland-inc/ci-templates/blob/94d34b659fbba97195e3f543a94dad40218f90ee/.github/workflows/js-bazel-package.yml#L121-L127)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`validate` job missing `permissions` block**

   The custom rule requires a `permissions` block on every job, defaulting to read-only. The `validate` job only needs `contents: read` for checkout; adding that restriction is safe (it's a reduction, not an escalation) and will not trigger the `startup_failure` that caused this PR. Without the block, the job silently inherits whatever the caller grants — which could be broader than necessary.

   **Context Used:** This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/js-bazel-package.yml
   Line: 121-127
   
   Comment:
   **`validate` job missing `permissions` block**
   
   The custom rule requires a `permissions` block on every job, defaulting to read-only. The `validate` job only needs `contents: read` for checkout; adding that restriction is safe (it's a reduction, not an escalation) and will not trigger the `startup_failure` that caused this PR. Without the block, the job silently inherits whatever the caller grants — which could be broader than necessary.
   
   
   
   **Context Used:** This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `.github/workflows/js-bazel-package.yml`, line 362-366 ([link](https://github.com/tinyland-inc/ci-templates/blob/94d34b659fbba97195e3f543a94dad40218f90ee/.github/workflows/js-bazel-package.yml#L362-L366)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Publish jobs lack required-permissions documentation**

   Both `publish-npm` and `publish-github` now inherit all caller-granted permissions without any in-file record of what they need. `publish-npm` requires `id-token: write` (provenance) and `publish-github` requires `packages: write`. A brief comment at each job would make the caller contract self-documenting and align with the rule to "justify any write permissions in comments."

   ```yaml
     publish-npm:
       needs: validate
       if: ${{ inputs.dry_run == false }}
       # No job-level permissions block: callers must grant id-token: write
       # (for npm provenance) and contents: read in their caller workflow.
   ```

   **Context Used:** This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/js-bazel-package.yml
   Line: 362-366
   
   Comment:
   **Publish jobs lack required-permissions documentation**
   
   Both `publish-npm` and `publish-github` now inherit all caller-granted permissions without any in-file record of what they need. `publish-npm` requires `id-token: write` (provenance) and `publish-github` requires `packages: write`. A brief comment at each job would make the caller contract self-documenting and align with the rule to "justify any write permissions in comments."
   
   ```yaml
     publish-npm:
       needs: validate
       if: ${{ inputs.dry_run == false }}
       # No job-level permissions block: callers must grant id-token: write
       # (for npm provenance) and contents: read in their caller workflow.
   ```
   
   **Context Used:** This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 121-127

Comment:
**`validate` job missing `permissions` block**

The custom rule requires a `permissions` block on every job, defaulting to read-only. The `validate` job only needs `contents: read` for checkout; adding that restriction is safe (it's a reduction, not an escalation) and will not trigger the `startup_failure` that caused this PR. Without the block, the job silently inherits whatever the caller grants — which could be broader than necessary.

```suggestion
  validate:
    runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
    timeout-minutes: 30
    permissions:
      contents: read
    strategy:
```

**Context Used:** This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 362-366

Comment:
**Publish jobs lack required-permissions documentation**

Both `publish-npm` and `publish-github` now inherit all caller-granted permissions without any in-file record of what they need. `publish-npm` requires `id-token: write` (provenance) and `publish-github` requires `packages: write`. A brief comment at each job would make the caller contract self-documenting and align with the rule to "justify any write permissions in comments."

```yaml
  publish-npm:
    needs: validate
    if: ${{ inputs.dry_run == false }}
    # No job-level permissions block: callers must grant id-token: write
    # (for npm provenance) and contents: read in their caller workflow.
```

**Context Used:** This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(permissions): remove per-job permiss..."](https://github.com/tinyland-inc/ci-templates/commit/94d34b659fbba97195e3f543a94dad40218f90ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28859311)</sub>

**Context used:**

- Context used - This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))

<!-- /greptile_comment -->