### PR TITLE
fix(js-bazel-package): honor shared runner labels

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -119,7 +119,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(inputs.runner_mode == 'shared' && inputs.shared_runner_labels_json || inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -362,7 +362,7 @@ jobs:
   publish-npm:
     needs: validate
     if: ${{ inputs.dry_run == false }}
-    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_mode == 'shared' && inputs.shared_runner_labels_json || inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     steps:
       - name: Validate publish contract
@@ -420,7 +420,7 @@ jobs:
   publish-github:
     needs: validate
     if: ${{ inputs.github_package_name != '' && inputs.dry_run == false }}
-    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_mode == 'shared' && inputs.shared_runner_labels_json || inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     steps:
       - name: Validate publish contract

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -142,6 +142,8 @@ jobs:
 - `runner_mode=repo_owned` should always pass explicit `runner_labels_json`.
 - `runner_mode=shared` uses `shared_runner_labels_json`, which defaults to
   `["tinyland-docker"]`.
+- `publish_mode=hosted_exception` intentionally overrides the selected runner
+  lane for publish jobs and uses `ubuntu-latest`.
 - self-hosted jobs now call `nix-setup`, so Attic and Bazel cache hints are
   explicit instead of incidental runner state.
 - `workspace_mode=isolated` is the preferred contract for downstream pilots.


### PR DESCRIPTION
## Summary
- make `runner_mode=shared` use `shared_runner_labels_json` for validation jobs
- apply the same shared runner lane to same-runner npm/GitHub publish jobs
- document that `publish_mode=hosted_exception` intentionally overrides runner selection to `ubuntu-latest`

## Validation
- `git diff --check`
- `actionlint` unavailable in the Codex harness

## Why
The reusable workflow advertised `runner_mode=shared`, but all `runs-on` expressions still read `runner_labels_json`. That made shared-mode consumers queue on the wrong/default lane unless they also overrode compat runner labels.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `runs-on` expressions in `validate`, `publish-npm`, and `publish-github` to route jobs through `shared_runner_labels_json` when `runner_mode=shared`, and adds a documentation note that `publish_mode=hosted_exception` intentionally overrides runner selection. The expression precedence chain (`hosted_exception` → `shared` → `runner_labels_json` → fallback) is logically correct.

- The PR description does not list which downstream repos consume this reusable workflow. The blast-radius rule requires consuming repos to be named so reviewers can assess the impact of the change.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the expression logic is correct, all actions remain pinned, and the change is additive.

Only P2-level findings (missing consuming-repo list in the PR description per the blast-radius rule). No logic errors, no security concerns, no broken fallback paths.

No files require special attention beyond the PR-description gap noted above.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Three `runs-on` expressions updated to route shared-mode jobs through `shared_runner_labels_json`; expression precedence and fallback chain are logically correct. |
| docs/js-bazel-package.md | Adds one documentation bullet clarifying that `publish_mode=hosted_exception` intentionally overrides runner selection to `ubuntu-latest`. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(js-bazel-package): honor shared runn..."](https://github.com/tinyland-inc/ci-templates/commit/c0ee4a21713eb91cc6fec2670054aab42b1aac22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29689985)</sub>

<!-- /greptile_comment -->