### PR TITLE
fix(js-bazel-package): restore startup-safe runs-on

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -119,7 +119,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ${{ fromJson(inputs.runner_mode == 'shared' && inputs.shared_runner_labels_json || inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -362,7 +362,7 @@ jobs:
   publish-npm:
     needs: validate
     if: ${{ inputs.dry_run == false }}
-    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_mode == 'shared' && inputs.shared_runner_labels_json || inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     steps:
       - name: Validate publish contract
@@ -420,7 +420,7 @@ jobs:
   publish-github:
     needs: validate
     if: ${{ inputs.github_package_name != '' && inputs.dry_run == false }}
-    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_mode == 'shared' && inputs.shared_runner_labels_json || inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
     timeout-minutes: 20
     steps:
       - name: Validate publish contract

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -140,8 +140,10 @@ jobs:
 - `compat` exists only to let existing consumers adopt the new template without
   breaking in one PR.
 - `runner_mode=repo_owned` should always pass explicit `runner_labels_json`.
-- `runner_mode=shared` uses `shared_runner_labels_json`, which defaults to
-  `["tinyland-docker"]`.
+- `runner_mode=shared` should currently pass the selected shared runner lane
+  through `runner_labels_json`; keep `shared_runner_labels_json` populated as
+  metadata for the future resolver, but avoid complex `runs-on` expressions
+  because they cause GitHub Actions startup failures before jobs are created.
 - `publish_mode=hosted_exception` intentionally overrides the selected runner
   lane for publish jobs and uses `ubuntu-latest`.
 - self-hosted jobs now call `nix-setup`, so Attic and Bazel cache hints are


### PR DESCRIPTION
## Summary
- restore the simple startup-safe `runs-on` expressions from #10/#11
- document that shared-mode consumers must currently pass their selected lane via `runner_labels_json`
- keep `publish_mode=hosted_exception` behavior unchanged

## Validation
- `git diff --check`

## Why
#12 reintroduced complex chained `runs-on` expressions and immediately caused caller workflow startup failure before any jobs were created. This restores the proven expression shape while keeping the shared-runner intent documented.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts the complex chained `runs-on` expressions from #12 to simpler `runner_labels_json`-only forms, fixing workflow startup failures, and updates documentation to direct `runner_mode=shared` consumers to pass their runner lane via `runner_labels_json`.

- The validate contract step only guards `runner_mode=repo_owned`; there is no equivalent guard for `runner_mode=shared`, so callers that pass `shared_runner_labels_json` but omit `runner_labels_json` will silently land on `ubuntu-latest` with no error.
- The `shared_runner_labels_json` input description still claims it is \"used when `runner_mode=shared`\", which directly contradicts the new routing behavior.

<h3>Confidence Score: 3/5</h3>

Safe to merge if callers using runner_mode=shared have already been updated to pass runner_labels_json; otherwise they will silently run on ubuntu-latest.

One P1 finding: missing contract enforcement for runner_mode=shared allows silent runner mismatch with no error. Score pulled below the P1 ceiling of 4 because the affected callers are spread across the org and the failure is completely silent.

.github/workflows/js-bazel-package.yml — validate step contract block and shared_runner_labels_json input description both need updates.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Simplifies `runs-on` expressions to use only `runner_labels_json`; drops `shared_runner_labels_json` from routing logic but retains the input and its misleading description. No contract check guards callers using `runner_mode=shared` without updating `runner_labels_json`, causing silent fallback to `ubuntu-latest`. |
| docs/js-bazel-package.md | Documentation updated to explain that `runner_mode=shared` consumers must now pass their runner lane via `runner_labels_json` and that `shared_runner_labels_json` is retained as future-resolver metadata only. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.github/workflows/js-bazel-package.yml`, line 154-157 ([link](https://github.com/tinyland-inc/ci-templates/blob/26cc90926d727b0830748b0c846082952860be0d/.github/workflows/js-bazel-package.yml#L154-L157)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing contract check for `runner_mode=shared`**

   After this change, a caller that passes `runner_mode=shared` and `shared_runner_labels_json` but omits `runner_labels_json` will silently land on `ubuntu-latest` — the default — instead of the intended shared runner. The validate step enforces `runner_mode=repo_owned` but has no equivalent guard for `runner_mode=shared`, so the misconfiguration produces no error and no warning.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/js-bazel-package.yml
   Line: 154-157

   Comment:
   **Missing contract check for `runner_mode=shared`**

   After this change, a caller that passes `runner_mode=shared` and `shared_runner_labels_json` but omits `runner_labels_json` will silently land on `ubuntu-latest` — the default — instead of the intended shared runner. The validate step enforces `runner_mode=repo_owned` but has no equivalent guard for `runner_mode=shared`, so the misconfiguration produces no error and no warning.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `.github/workflows/js-bazel-package.yml`, line 11-14 ([link](https://github.com/tinyland-inc/ci-templates/blob/26cc90926d727b0830748b0c846082952860be0d/.github/workflows/js-bazel-package.yml#L11-L14)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`shared_runner_labels_json` description is now misleading**

   The description still says it is "used when `runner_mode=shared`", but after this change the input is never consulted by any `runs-on` expression. A caller reading the input spec will think passing this value is sufficient for shared-runner routing. The description should clarify that it is now metadata-only.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/js-bazel-package.yml
   Line: 11-14

   Comment:
   **`shared_runner_labels_json` description is now misleading**

   The description still says it is "used when `runner_mode=shared`", but after this change the input is never consulted by any `runs-on` expression. A caller reading the input spec will think passing this value is sufficient for shared-runner routing. The description should clarify that it is now metadata-only.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 154-157

Comment:
**Missing contract check for `runner_mode=shared`**

After this change, a caller that passes `runner_mode=shared` and `shared_runner_labels_json` but omits `runner_labels_json` will silently land on `ubuntu-latest` — the default — instead of the intended shared runner. The validate step enforces `runner_mode=repo_owned` but has no equivalent guard for `runner_mode=shared`, so the misconfiguration produces no error and no warning.

```suggestion
          if [ "${{ inputs.runner_mode }}" = "repo_owned" ] && [ "${{ inputs.runner_labels_json }}" = '["ubuntu-latest"]' ]; then
            echo "runner_mode=repo_owned requires explicit runner_labels_json" >&2
            exit 1
          fi
          if [ "${{ inputs.runner_mode }}" = "shared" ] && [ "${{ inputs.runner_labels_json }}" = '["ubuntu-latest"]' ]; then
            echo "runner_mode=shared currently requires explicit runner_labels_json (see docs/js-bazel-package.md)" >&2
            exit 1
          fi
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 11-14

Comment:
**`shared_runner_labels_json` description is now misleading**

The description still says it is "used when `runner_mode=shared`", but after this change the input is never consulted by any `runs-on` expression. A caller reading the input spec will think passing this value is sufficient for shared-runner routing. The description should clarify that it is now metadata-only.

```suggestion
      shared_runner_labels_json:
        description: "JSON array of shared GloriousFlywheel runner labels (metadata only; pass the selected lane via runner_labels_json instead — see docs/js-bazel-package.md)"
        type: string
        default: '["tinyland-docker"]'
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(js-bazel-package): restore startup-s..."](https://github.com/tinyland-inc/ci-templates/commit/26cc90926d727b0830748b0c846082952860be0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29690747)</sub>

<!-- /greptile_comment -->