### PR TITLE
fix(js-bazel-package): resolve shared runner labels

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -118,8 +118,89 @@ on:
         required: false
 
 jobs:
+  resolve-runner:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      validate_runner_labels_json: ${{ steps.resolve.outputs.validate_runner_labels_json }}
+      publish_runner_labels_json: ${{ steps.resolve.outputs.publish_runner_labels_json }}
+    steps:
+      - name: Resolve runner labels
+        id: resolve
+        shell: bash
+        env:
+          RUNNER_MODE: ${{ inputs.runner_mode }}
+          RUNNER_LABELS_JSON: ${{ inputs.runner_labels_json }}
+          SHARED_RUNNER_LABELS_JSON: ${{ inputs.shared_runner_labels_json }}
+          PUBLISH_MODE: ${{ inputs.publish_mode }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+
+          runner_mode = os.environ.get("RUNNER_MODE") or "compat"
+          publish_mode = os.environ.get("PUBLISH_MODE") or "same_runner"
+
+          if runner_mode not in {"compat", "hosted", "shared", "repo_owned"}:
+              raise SystemExit(f"Unsupported runner_mode: {runner_mode}")
+
+          if publish_mode not in {"same_runner", "hosted_exception"}:
+              raise SystemExit(f"Unsupported publish_mode: {publish_mode}")
+
+          def parse_labels(name: str, fallback: str) -> list[str]:
+              raw = os.environ.get(name) or fallback
+              try:
+                  labels = json.loads(raw)
+              except json.JSONDecodeError as exc:
+                  raise SystemExit(f"{name} must be a JSON array: {exc}") from exc
+
+              if (
+                  not isinstance(labels, list)
+                  or not labels
+                  or not all(isinstance(label, str) and label for label in labels)
+              ):
+                  raise SystemExit(f"{name} must be a non-empty JSON array of strings")
+
+              return labels
+
+          runner_labels = parse_labels("RUNNER_LABELS_JSON", '["ubuntu-latest"]')
+          shared_runner_labels = parse_labels(
+              "SHARED_RUNNER_LABELS_JSON",
+              '["tinyland-docker"]',
+          )
+
+          if runner_mode == "hosted":
+              validate_runner_labels = ["ubuntu-latest"]
+          elif runner_mode == "shared":
+              validate_runner_labels = shared_runner_labels
+          else:
+              validate_runner_labels = runner_labels
+
+          if runner_mode == "repo_owned" and validate_runner_labels == ["ubuntu-latest"]:
+              raise SystemExit("runner_mode=repo_owned requires explicit runner_labels_json")
+
+          if publish_mode == "hosted_exception":
+              publish_runner_labels = ["ubuntu-latest"]
+          else:
+              publish_runner_labels = validate_runner_labels
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              print(
+                  "validate_runner_labels_json="
+                  + json.dumps(validate_runner_labels, separators=(",", ":")),
+                  file=output,
+              )
+              print(
+                  "publish_runner_labels_json="
+                  + json.dumps(publish_runner_labels, separators=(",", ":")),
+                  file=output,
+              )
+          PY
+
   validate:
-    runs-on: ${{ fromJson(inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    needs: resolve-runner
+    runs-on: ${{ fromJson(needs.resolve-runner.outputs.validate_runner_labels_json) }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -293,7 +374,9 @@ jobs:
         run: |
           set -euo pipefail
           cd "$WORKSPACE_DIR"
-          npx --yes @bazel/bazelisk build $BAZEL_TARGETS --verbose_failures
+          # shellcheck disable=SC2153
+          read -r -a bazel_targets <<< "$BAZEL_TARGETS"
+          npx --yes @bazel/bazelisk build "${bazel_targets[@]}" --verbose_failures
 
       - name: Validate npm tarball from Bazel artifact
         shell: bash
@@ -360,9 +443,11 @@ jobs:
           if-no-files-found: error
 
   publish-npm:
-    needs: validate
+    needs:
+      - resolve-runner
+      - validate
     if: ${{ inputs.dry_run == false }}
-    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(needs.resolve-runner.outputs.publish_runner_labels_json) }}
     timeout-minutes: 20
     steps:
       - name: Validate publish contract
@@ -418,9 +503,11 @@ jobs:
           npm publish "${PUBLISH_ARGS[@]}"
 
   publish-github:
-    needs: validate
+    needs:
+      - resolve-runner
+      - validate
     if: ${{ inputs.github_package_name != '' && inputs.dry_run == false }}
-    runs-on: ${{ fromJson(inputs.publish_mode == 'hosted_exception' && '["ubuntu-latest"]' || inputs.runner_labels_json || '["ubuntu-latest"]') }}
+    runs-on: ${{ fromJson(needs.resolve-runner.outputs.publish_runner_labels_json) }}
     timeout-minutes: 20
     steps:
       - name: Validate publish contract

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -74,7 +74,9 @@ jobs:
 
       - name: Verify no source maps in package
         run: |
-          npm pack --dry-run 2>&1 | grep '\.js\.map' && exit 1 || true
+          if npm pack --dry-run 2>&1 | grep '\.js\.map'; then
+            exit 1
+          fi
 
   publish-gpr:
     needs: build-and-test

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -140,10 +140,10 @@ jobs:
 - `compat` exists only to let existing consumers adopt the new template without
   breaking in one PR.
 - `runner_mode=repo_owned` should always pass explicit `runner_labels_json`.
-- `runner_mode=shared` should currently pass the selected shared runner lane
-  through `runner_labels_json`; keep `shared_runner_labels_json` populated as
-  metadata for the future resolver, but avoid complex `runs-on` expressions
-  because they cause GitHub Actions startup failures before jobs are created.
+- `runner_mode=shared` uses `shared_runner_labels_json`. The workflow resolves
+  the selected labels in a small hosted setup job, then passes simple JSON
+  outputs into `runs-on` to avoid the complex inline expressions that previously
+  caused GitHub Actions startup failures before jobs were created.
 - `publish_mode=hosted_exception` intentionally overrides the selected runner
   lane for publish jobs and uses `ubuntu-latest`.
 - self-hosted jobs now call `nix-setup`, so Attic and Bazel cache hints are


### PR DESCRIPTION
## Summary

- add a small resolver job for `js-bazel-package.yml` runner selection
- make `runner_mode=shared` use `shared_runner_labels_json` for validate and same-runner publish jobs
- keep `hosted_exception` publish jobs on `ubuntu-latest`
- clean up workflow lint findings surfaced by `actionlint`

## Validation

- `nix shell nixpkgs#actionlint -c actionlint`
- `git diff --check`

Fixes #14.
Tracking: TIN-555.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a small `resolve-runner` setup job in `js-bazel-package.yml` that computes the correct runner labels for `runner_mode=shared` (using `shared_runner_labels_json`) and passes them as simple JSON outputs to downstream jobs, replacing the fragile inline `fromJson` expression. It also fixes a Bazel targets word-splitting bug and cleans up a `&&…|| true` anti-pattern in `npm-publish.yml`.

The PR description does not list which repos consume the changed reusable workflow. Per the blast-radius policy, PR descriptions for changes to reusable workflows must enumerate downstream consumers.

<h3>Confidence Score: 4/5</h3>

Safe to merge after adding a permissions block to the new job and noting downstream consumers in the PR description.

Only P2 findings: missing permissions block on the new resolve-runner job (repo policy) and an absent downstream-consumer list in the PR description (blast-radius policy). No logic errors, no secrets exposure, and no broken contracts.

.github/workflows/js-bazel-package.yml — resolve-runner job missing permissions block.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Adds resolve-runner job to correctly route shared/hosted/repo_owned runner labels; fixes Bazel targets word-splitting; new job is missing a permissions block per repo policy. |
| .github/workflows/npm-publish.yml | Fixes source-map check from error-prone &&…|| idiom to a proper if/exit; action refs remain floating tags (pre-existing, not introduced here). |
| docs/js-bazel-package.md | Documentation updated to reflect the new resolver job approach for runner_mode=shared; no issues found. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 121-123

Comment:
**Missing `permissions` block on new `resolve-runner` job**

The `resolve-runner` job has no `permissions` block. Per the repo rule, every job must declare a `permissions` block defaulting to read-only. This job only writes to `GITHUB_OUTPUT` and needs no GitHub API permissions, so an empty (or `contents: read`) block is appropriate.

```suggestion
  resolve-runner:
    runs-on: ubuntu-latest
    permissions: {}
    timeout-minutes: 5
```

**Context Used:** This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(js-bazel-package): resolve shared ru..."](https://github.com/tinyland-inc/ci-templates/commit/bbeafc76344e73093d343b74dee2b6295127a4ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29693503)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))

<!-- /greptile_comment -->