### PR TITLE
ci: retry transient Bazel fetch failures

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -84,6 +84,10 @@ on:
         description: "Space-delimited Bazel targets to validate"
         type: string
         default: "//:pkg"
+      bazel_fetch_retry_attempts:
+        description: "Bazel validation attempts for transient external archive fetch failures"
+        type: string
+        default: "3"
       package_dir:
         description: "Directory containing the Bazel-built publishable package"
         type: string
@@ -232,6 +236,17 @@ jobs:
               exit 1
               ;;
           esac
+          bazel_fetch_retry_attempts="${{ inputs.bazel_fetch_retry_attempts }}"
+          case "$bazel_fetch_retry_attempts" in
+            ""|*[!0-9]*)
+              echo "bazel_fetch_retry_attempts must be a positive integer" >&2
+              exit 1
+              ;;
+          esac
+          if [ "$bazel_fetch_retry_attempts" -lt 1 ] || [ "$bazel_fetch_retry_attempts" -gt 5 ]; then
+            echo "bazel_fetch_retry_attempts must be between 1 and 5" >&2
+            exit 1
+          fi
           if [ "${{ inputs.runner_mode }}" = "repo_owned" ] && [ "${{ inputs.runner_labels_json }}" = '["ubuntu-latest"]' ]; then
             echo "runner_mode=repo_owned requires explicit runner_labels_json" >&2
             exit 1
@@ -371,12 +386,40 @@ jobs:
         shell: bash
         env:
           BAZEL_TARGETS: ${{ inputs.bazel_targets || '//:pkg' }}
+          BAZEL_FETCH_RETRY_ATTEMPTS: ${{ inputs.bazel_fetch_retry_attempts || '3' }}
         run: |
           set -euo pipefail
           cd "$WORKSPACE_DIR"
           # shellcheck disable=SC2153
           read -r -a bazel_targets <<< "$BAZEL_TARGETS"
-          npx --yes @bazel/bazelisk build "${bazel_targets[@]}" --verbose_failures
+
+          attempts="$BAZEL_FETCH_RETRY_ATTEMPTS"
+          attempt=1
+          while [ "$attempt" -le "$attempts" ]; do
+            log_path="$RUNNER_TEMP/js-bazel-package-bazel-attempt-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${{ matrix.node-version }}-${attempt}.log"
+            set +e
+            npx --yes @bazel/bazelisk build "${bazel_targets[@]}" --verbose_failures 2>&1 | tee "$log_path"
+            status="${PIPESTATUS[0]}"
+            set -e
+
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+
+            if [ "$attempt" -eq "$attempts" ]; then
+              echo "::error::Bazel validation failed after $attempts attempt(s)."
+              exit "$status"
+            fi
+
+            if ! grep -Eiq "(Error downloading|GET returned 5[0-9][0-9]|Bad Gateway|Proxy Error|connection reset|Connection timed out|TLS handshake timeout|Temporary failure)" "$log_path"; then
+              echo "::error::Bazel validation failed with a non-fetch error; not retrying."
+              exit "$status"
+            fi
+
+            echo "::warning::Bazel validation hit a transient external fetch/download failure on attempt $attempt/$attempts; retrying."
+            npx --yes @bazel/bazelisk shutdown >/dev/null 2>&1 || true
+            attempt=$((attempt + 1))
+          done
 
       - name: Validate npm tarball from Bazel artifact
         shell: bash

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -401,7 +401,7 @@ jobs:
           attempts="$BAZEL_FETCH_RETRY_ATTEMPTS"
           attempt=1
           while [ "$attempt" -le "$attempts" ]; do
-            log_path="$RUNNER_TEMP/js-bazel-package-bazel-attempt-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${{ matrix.node-version }}-${attempt}.log"
+            log_path="$RUNNER_TEMP/js-bazel-package-bazel-attempt-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${NODE_VERSION}-${attempt}.log"
             set +e
             npx --yes @bazel/bazelisk build "${bazel_targets[@]}" --verbose_failures 2>&1 | tee "$log_path"
             status="${PIPESTATUS[0]}"

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -213,41 +213,46 @@ jobs:
     steps:
       - name: Validate workflow contract
         shell: bash
+        env:
+          RUNNER_MODE: ${{ inputs.runner_mode }}
+          RUNNER_LABELS_JSON: ${{ inputs.runner_labels_json }}
+          WORKSPACE_MODE: ${{ inputs.workspace_mode }}
+          PUBLISH_MODE: ${{ inputs.publish_mode }}
+          BAZEL_FETCH_RETRY_ATTEMPTS: ${{ inputs.bazel_fetch_retry_attempts }}
         run: |
           set -euo pipefail
-          case "${{ inputs.runner_mode }}" in
+          case "$RUNNER_MODE" in
             compat|hosted|shared|repo_owned) ;;
             *)
-              echo "Unsupported runner_mode: ${{ inputs.runner_mode }}" >&2
+              echo "Unsupported runner_mode: $RUNNER_MODE" >&2
               exit 1
               ;;
           esac
-          case "${{ inputs.workspace_mode }}" in
+          case "$WORKSPACE_MODE" in
             isolated|persistent_compat) ;;
             *)
-              echo "Unsupported workspace_mode: ${{ inputs.workspace_mode }}" >&2
+              echo "Unsupported workspace_mode: $WORKSPACE_MODE" >&2
               exit 1
               ;;
           esac
-          case "${{ inputs.publish_mode }}" in
+          case "$PUBLISH_MODE" in
             same_runner|hosted_exception) ;;
             *)
-              echo "Unsupported publish_mode: ${{ inputs.publish_mode }}" >&2
+              echo "Unsupported publish_mode: $PUBLISH_MODE" >&2
               exit 1
               ;;
           esac
-          bazel_fetch_retry_attempts="${{ inputs.bazel_fetch_retry_attempts }}"
-          case "$bazel_fetch_retry_attempts" in
+          case "$BAZEL_FETCH_RETRY_ATTEMPTS" in
             ""|*[!0-9]*)
               echo "bazel_fetch_retry_attempts must be a positive integer" >&2
               exit 1
               ;;
           esac
-          if [ "$bazel_fetch_retry_attempts" -lt 1 ] || [ "$bazel_fetch_retry_attempts" -gt 5 ]; then
+          if [ "$BAZEL_FETCH_RETRY_ATTEMPTS" -lt 1 ] || [ "$BAZEL_FETCH_RETRY_ATTEMPTS" -gt 5 ]; then
             echo "bazel_fetch_retry_attempts must be between 1 and 5" >&2
             exit 1
           fi
-          if [ "${{ inputs.runner_mode }}" = "repo_owned" ] && [ "${{ inputs.runner_labels_json }}" = '["ubuntu-latest"]' ]; then
+          if [ "$RUNNER_MODE" = "repo_owned" ] && [ "$RUNNER_LABELS_JSON" = '["ubuntu-latest"]' ]; then
             echo "runner_mode=repo_owned requires explicit runner_labels_json" >&2
             exit 1
           fi
@@ -418,6 +423,7 @@ jobs:
 
             echo "::warning::Bazel validation hit a transient external fetch/download failure on attempt $attempt/$attempts; retrying."
             npx --yes @bazel/bazelisk shutdown >/dev/null 2>&1 || true
+            sleep 10
             attempt=$((attempt + 1))
           done
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Reusable workflow for JS/TS packages whose release artifact is built by Bazel an
 
 Supports explicit runner policy (`compat`, `hosted`, `shared`, `repo_owned`), explicit workspace policy (`isolated`, `persistent_compat`), explicit publish policy (`same_runner`, `hosted_exception`), self-hosted cache contract wiring, optional advisory lint/typecheck lanes, Bazel-artifact dry-runs, and npm/GitHub Packages publication from the extracted Bazel package.
 
+The Bazel validation step includes bounded retries for transient external
+archive fetch failures, so package repos do not each vendor ad hoc GitHub
+release-download retry logic.
+
 See [docs/js-bazel-package.md](./docs/js-bazel-package.md) for usage and inputs.
 
 ### `npm-publish`

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -144,6 +144,10 @@ jobs:
   the selected labels in a small hosted setup job, then passes simple JSON
   outputs into `runs-on` to avoid the complex inline expressions that previously
   caused GitHub Actions startup failures before jobs were created.
+- `bazel_fetch_retry_attempts` defaults to `3` and only retries Bazel target
+  validation when the build log matches transient external archive fetch
+  failures, such as upstream GitHub release `502` responses. Deterministic
+  compile/test failures are not retried.
 - `publish_mode=hosted_exception` intentionally overrides the selected runner
   lane for publish jobs and uses `ubuntu-latest`.
 - self-hosted jobs now call `nix-setup`, so Attic and Bazel cache hints are


### PR DESCRIPTION
## Summary

Hardens the reusable `js-bazel-package` workflow against transient upstream archive fetch failures during Bazel target validation.

- adds `bazel_fetch_retry_attempts`, defaulting to `3`
- validates the retry count as an integer between `1` and `5`
- retries only when the Bazel log matches transient external fetch/download failures such as GitHub release `502` responses
- does not retry deterministic compile/test failures
- documents the behavior in `README.md` and `docs/js-bazel-package.md`

## Context

This directly addresses the repeated scheduling package lane failures captured in `ci-templates#16` / `TIN-558`:

- `rules_nodejs-v6.7.3.tar.gz` transient GitHub `502`
- `rules_java-8.6.1.tar.gz` transient GitHub `502`

Both failures reran cleanly with no package repo code changes, so the fix belongs in the shared workflow rather than in each package repo.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/js-bazel-package.yml"); puts "yaml ok"'`
- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/js-bazel-package.yml`
- `git diff --check`

Refs: #16, TIN-558, Jesssullivan/scheduling-kit#77

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the `js-bazel-package` reusable workflow against transient Bazel archive fetch failures by adding a bounded retry loop (new `bazel_fetch_retry_attempts` input, default 3, validated 1–5) and moves all `inputs.*` references in the "Validate workflow contract" step behind `env:` bindings. The retry logic correctly guards on a transient-error grep pattern, includes a 10-second backoff, and cleanly exits on deterministic failures or on exhaustion.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no new P1/P0 issues introduced by the changed code.

All new shell variable expansions go through env: bindings, PIPESTATUS usage is correct under set +e, input validation is correctly ordered before the retry step, and the grep pattern covers the documented failure modes. No prior-thread issues are reintroduced.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Adds bazel_fetch_retry_attempts input with validation, moves all validate-step inputs behind env: bindings (fixing injection), and introduces a retry loop with transient-error grep guard and sleep 10 backoff. |
| README.md | Minor prose addition describing the bounded retry behaviour; no issues. |
| docs/js-bazel-package.md | Documents the new bazel_fetch_retry_attempts input behaviour; no issues. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["Update .github/workflows/js-bazel-packag..."](https://github.com/tinyland-inc/ci-templates/commit/69d1485d45d2e793775fac762ed4e68bd3261a11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29723771)</sub>

<!-- /greptile_comment -->