### PR TITLE
ci: define node version for Bazel retry logs

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -218,7 +218,7 @@ jobs:
           RUNNER_LABELS_JSON: ${{ inputs.runner_labels_json }}
           WORKSPACE_MODE: ${{ inputs.workspace_mode }}
           PUBLISH_MODE: ${{ inputs.publish_mode }}
-          BAZEL_FETCH_RETRY_ATTEMPTS: ${{ inputs.bazel_fetch_retry_attempts }}
+          BAZEL_FETCH_RETRY_ATTEMPTS: ${{ inputs.bazel_fetch_retry_attempts || '3' }}
         run: |
           set -euo pipefail
           case "$RUNNER_MODE" in
@@ -392,6 +392,7 @@ jobs:
         env:
           BAZEL_TARGETS: ${{ inputs.bazel_targets || '//:pkg' }}
           BAZEL_FETCH_RETRY_ATTEMPTS: ${{ inputs.bazel_fetch_retry_attempts || '3' }}
+          NODE_VERSION: ${{ matrix.node-version }}
         run: |
           set -euo pipefail
           cd "$WORKSPACE_DIR"


### PR DESCRIPTION
## Summary

- Define `NODE_VERSION` in the Bazel retry validation step from `matrix.node-version`.
- Align the workflow contract validation default for `bazel_fetch_retry_attempts` with the actual retry step default.

## Why

`ci-templates#17` added retry-scoped Bazel log paths containing `${NODE_VERSION}`, but the shell environment did not define that variable. Consumer PRs hit `NODE_VERSION: unbound variable` as soon as the retry-enabled Bazel validation step ran.

## Validation

- `git diff --check`
- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/js-bazel-package.yml`

## Follow-Up

After this lands, consumer pin PRs can be repointed from `304bd18ba1b46a1b07f58aa36a99253e4f287178` to this corrected merge SHA.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related gaps introduced by #17: the missing `NODE_VERSION` env var that caused `set -euo pipefail` to abort the Bazel retry step immediately with an unbound-variable error, and a missing `|| '3'` fallback in the contract-validation step that left `BAZEL_FETCH_RETRY_ATTEMPTS` unguarded against an explicit empty-string caller. Both fixes are minimal, correct, and consistent with the patterns already present in the file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are surgical fixes with no new blast-radius concerns.

No P0/P1 findings. The NODE_VERSION binding is sourced correctly from matrix.node-version, the || '3' fallback is consistent with the input default and the retry step, and all custom rules (shell: bash, set -euo pipefail, env-var quoting, timeout-minutes) continue to be satisfied on the changed lines.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Two targeted fixes: adds NODE_VERSION env var to the Bazel retry step (fixing unbound variable crash) and aligns the contract-validation fallback default for bazel_fetch_retry_attempts with the retry step. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: define node version for Bazel retry ..."](https://github.com/tinyland-inc/ci-templates/commit/fe6ea1c776981402a7f9ba61abf92c3e48dc8bba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29726320)</sub>

<!-- /greptile_comment -->