### PR TITLE
ci: retry Bazel fetches across package commands

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -487,7 +487,8 @@ jobs:
 
           # shellcheck source=/dev/null
           source "$BAZEL_FETCH_RETRY_HELPER"
-          run_with_bazel_fetch_retry "Validate Bazel targets" "npx --yes @bazel/bazelisk build ${bazel_targets[*]} --verbose_failures"
+          targets_quoted="$(printf '%q ' "${bazel_targets[@]}")"
+          run_with_bazel_fetch_retry "Validate Bazel targets" "npx --yes @bazel/bazelisk build ${targets_quoted}--verbose_failures"
 
       - name: Validate npm tarball from Bazel artifact
         shell: bash

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -206,6 +206,9 @@ jobs:
     needs: resolve-runner
     runs-on: ${{ fromJson(needs.resolve-runner.outputs.validate_runner_labels_json) }}
     timeout-minutes: 30
+    env:
+      BAZEL_FETCH_RETRY_ATTEMPTS: ${{ inputs.bazel_fetch_retry_attempts || '3' }}
+      NODE_VERSION: ${{ matrix.node-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -322,111 +325,169 @@ jobs:
             pnpm install --no-frozen-lockfile
           fi
 
-      - name: Prepare workspace
-        if: ${{ inputs.prepare_command != '' }}
+      - name: Install Bazel fetch retry helper
         shell: bash
         run: |
           set -euo pipefail
+          helper_path="$RUNNER_TEMP/js-bazel-package-bazel-fetch-retry.sh"
+          cat > "$helper_path" <<'BASH'
+          is_transient_bazel_fetch_failure() {
+            local log_path="$1"
+            grep -Eiq "(Error downloading|GET returned 5[0-9][0-9]|Bad Gateway|Proxy Error|connection reset|Connection timed out|TLS handshake timeout|Temporary failure)" "$log_path"
+          }
+
+          run_with_bazel_fetch_retry() {
+            local label="$1"
+            local command="$2"
+            local attempts="${BAZEL_FETCH_RETRY_ATTEMPTS:-3}"
+            local attempt=1
+            local slug
+
+            slug="$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '-' | sed -E 's/^-+//; s/-+$//')"
+            if [ -z "$slug" ]; then
+              slug="command"
+            fi
+
+            while [ "$attempt" -le "$attempts" ]; do
+              local log_path="$RUNNER_TEMP/js-bazel-package-${slug}-attempt-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${NODE_VERSION:-unknown}-${attempt}.log"
+              set +e
+              bash -e -u -o pipefail -c "$command" 2>&1 | tee "$log_path"
+              local status="${PIPESTATUS[0]}"
+              set -e
+
+              if [ "$status" -eq 0 ]; then
+                return 0
+              fi
+
+              if [ "$attempt" -eq "$attempts" ]; then
+                echo "::error::$label failed after $attempts attempt(s)."
+                return "$status"
+              fi
+
+              if ! is_transient_bazel_fetch_failure "$log_path"; then
+                echo "::error::$label failed with a non-fetch error; not retrying."
+                return "$status"
+              fi
+
+              echo "::warning::$label hit a transient Bazel external fetch/download failure on attempt $attempt/$attempts; retrying."
+              npx --yes @bazel/bazelisk shutdown >/dev/null 2>&1 || true
+              sleep 10
+              attempt=$((attempt + 1))
+            done
+          }
+          BASH
+          echo "BAZEL_FETCH_RETRY_HELPER=$helper_path" >> "$GITHUB_ENV"
+
+      - name: Prepare workspace
+        if: ${{ inputs.prepare_command != '' }}
+        shell: bash
+        env:
+          COMMAND: ${{ inputs.prepare_command }}
+        run: |
+          set -euo pipefail
           cd "$WORKSPACE_DIR"
-          ${{ inputs.prepare_command }}
+          # shellcheck source=/dev/null
+          source "$BAZEL_FETCH_RETRY_HELPER"
+          run_with_bazel_fetch_retry "Prepare workspace" "$COMMAND"
 
       - name: Verify release metadata
         if: ${{ inputs.metadata_check_command != '' }}
         shell: bash
+        env:
+          COMMAND: ${{ inputs.metadata_check_command }}
         run: |
           set -euo pipefail
           cd "$WORKSPACE_DIR"
-          ${{ inputs.metadata_check_command }}
+          # shellcheck source=/dev/null
+          source "$BAZEL_FETCH_RETRY_HELPER"
+          run_with_bazel_fetch_retry "Verify release metadata" "$COMMAND"
 
       - name: Lint
         if: ${{ inputs.lint_command != '' }}
         continue-on-error: ${{ inputs.lint_continue_on_error }}
         shell: bash
+        env:
+          COMMAND: ${{ inputs.lint_command }}
         run: |
           set -euo pipefail
           cd "$WORKSPACE_DIR"
-          ${{ inputs.lint_command }}
+          # shellcheck source=/dev/null
+          source "$BAZEL_FETCH_RETRY_HELPER"
+          run_with_bazel_fetch_retry "Lint" "$COMMAND"
 
       - name: Typecheck
         if: ${{ inputs.typecheck_command != '' }}
         continue-on-error: ${{ inputs.typecheck_continue_on_error }}
         shell: bash
+        env:
+          COMMAND: ${{ inputs.typecheck_command }}
         run: |
           set -euo pipefail
           cd "$WORKSPACE_DIR"
-          ${{ inputs.typecheck_command }}
+          # shellcheck source=/dev/null
+          source "$BAZEL_FETCH_RETRY_HELPER"
+          run_with_bazel_fetch_retry "Typecheck" "$COMMAND"
 
       - name: Unit tests
         if: ${{ inputs.unit_test_command != '' }}
         shell: bash
+        env:
+          COMMAND: ${{ inputs.unit_test_command }}
         run: |
           set -euo pipefail
           cd "$WORKSPACE_DIR"
-          ${{ inputs.unit_test_command }}
+          # shellcheck source=/dev/null
+          source "$BAZEL_FETCH_RETRY_HELPER"
+          run_with_bazel_fetch_retry "Unit tests" "$COMMAND"
 
       - name: Integration tests
         if: ${{ inputs.integration_test_command != '' }}
         shell: bash
+        env:
+          COMMAND: ${{ inputs.integration_test_command }}
         run: |
           set -euo pipefail
           cd "$WORKSPACE_DIR"
-          ${{ inputs.integration_test_command }}
+          # shellcheck source=/dev/null
+          source "$BAZEL_FETCH_RETRY_HELPER"
+          run_with_bazel_fetch_retry "Integration tests" "$COMMAND"
 
       - name: Build workspace artifact
         shell: bash
+        env:
+          COMMAND: ${{ inputs.build_command || 'pnpm build' }}
         run: |
           set -euo pipefail
           cd "$WORKSPACE_DIR"
-          ${{ inputs.build_command || 'pnpm build' }}
+          # shellcheck source=/dev/null
+          source "$BAZEL_FETCH_RETRY_HELPER"
+          run_with_bazel_fetch_retry "Build workspace artifact" "$COMMAND"
 
       - name: Validate package surface
         if: ${{ inputs.package_check_command != '' }}
         shell: bash
+        env:
+          COMMAND: ${{ inputs.package_check_command }}
         run: |
           set -euo pipefail
           cd "$WORKSPACE_DIR"
-          ${{ inputs.package_check_command }}
+          # shellcheck source=/dev/null
+          source "$BAZEL_FETCH_RETRY_HELPER"
+          run_with_bazel_fetch_retry "Validate package surface" "$COMMAND"
 
       - name: Validate Bazel targets
         shell: bash
         env:
           BAZEL_TARGETS: ${{ inputs.bazel_targets || '//:pkg' }}
-          BAZEL_FETCH_RETRY_ATTEMPTS: ${{ inputs.bazel_fetch_retry_attempts || '3' }}
-          NODE_VERSION: ${{ matrix.node-version }}
         run: |
           set -euo pipefail
           cd "$WORKSPACE_DIR"
           # shellcheck disable=SC2153
           read -r -a bazel_targets <<< "$BAZEL_TARGETS"
 
-          attempts="$BAZEL_FETCH_RETRY_ATTEMPTS"
-          attempt=1
-          while [ "$attempt" -le "$attempts" ]; do
-            log_path="$RUNNER_TEMP/js-bazel-package-bazel-attempt-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}-${NODE_VERSION}-${attempt}.log"
-            set +e
-            npx --yes @bazel/bazelisk build "${bazel_targets[@]}" --verbose_failures 2>&1 | tee "$log_path"
-            status="${PIPESTATUS[0]}"
-            set -e
-
-            if [ "$status" -eq 0 ]; then
-              exit 0
-            fi
-
-            if [ "$attempt" -eq "$attempts" ]; then
-              echo "::error::Bazel validation failed after $attempts attempt(s)."
-              exit "$status"
-            fi
-
-            if ! grep -Eiq "(Error downloading|GET returned 5[0-9][0-9]|Bad Gateway|Proxy Error|connection reset|Connection timed out|TLS handshake timeout|Temporary failure)" "$log_path"; then
-              echo "::error::Bazel validation failed with a non-fetch error; not retrying."
-              exit "$status"
-            fi
-
-            echo "::warning::Bazel validation hit a transient external fetch/download failure on attempt $attempt/$attempts; retrying."
-            npx --yes @bazel/bazelisk shutdown >/dev/null 2>&1 || true
-            sleep 10
-            attempt=$((attempt + 1))
-          done
+          # shellcheck source=/dev/null
+          source "$BAZEL_FETCH_RETRY_HELPER"
+          run_with_bazel_fetch_retry "Validate Bazel targets" "npx --yes @bazel/bazelisk build ${bazel_targets[*]} --verbose_failures"
 
       - name: Validate npm tarball from Bazel artifact
         shell: bash

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Reusable workflow for JS/TS packages whose release artifact is built by Bazel an
 
 Supports explicit runner policy (`compat`, `hosted`, `shared`, `repo_owned`), explicit workspace policy (`isolated`, `persistent_compat`), explicit publish policy (`same_runner`, `hosted_exception`), self-hosted cache contract wiring, optional advisory lint/typecheck lanes, Bazel-artifact dry-runs, and npm/GitHub Packages publication from the extracted Bazel package.
 
-The Bazel validation step includes bounded retries for transient external
-archive fetch failures, so package repos do not each vendor ad hoc GitHub
-release-download retry logic.
+Consumer-supplied validation commands and the explicit Bazel validation step
+include bounded retries for transient Bazel external archive fetch failures, so
+package repos do not each vendor ad hoc GitHub release-download retry logic.
 
 See [docs/js-bazel-package.md](./docs/js-bazel-package.md) for usage and inputs.
 

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -144,10 +144,11 @@ jobs:
   the selected labels in a small hosted setup job, then passes simple JSON
   outputs into `runs-on` to avoid the complex inline expressions that previously
   caused GitHub Actions startup failures before jobs were created.
-- `bazel_fetch_retry_attempts` defaults to `3` and only retries Bazel target
-  validation when the build log matches transient external archive fetch
-  failures, such as upstream GitHub release `502` responses. Deterministic
-  compile/test failures are not retried.
+- `bazel_fetch_retry_attempts` defaults to `3` and wraps consumer-provided
+  validation commands plus explicit Bazel target validation. It only retries
+  when the command log matches transient Bazel external archive fetch failures,
+  such as upstream GitHub release `502` responses. Deterministic compile/test
+  failures are not retried.
 - `publish_mode=hosted_exception` intentionally overrides the selected runner
   lane for publish jobs and uses `ubuntu-latest`.
 - self-hosted jobs now call `nix-setup`, so Attic and Bazel cache hints are


### PR DESCRIPTION
## Summary

Extends the existing transient Bazel external fetch retry wrapper beyond the explicit Bazel validation step. Consumer-supplied package commands now use the same bounded retry helper, covering prepare, metadata, lint, typecheck, unit, integration, build, and package surface validation commands that may invoke Bazel indirectly.

This addresses the post-merge evidence in ci-templates#16 where scheduling-bridge failed during Typecheck on a transient Bazel external archive 502 before reaching the protected Bazel validation step.

Greptile flagged a target quoting regression in the first revision; the follow-up commit now preserves target argument quoting with `printf %q` before routing the command through the retry helper.

## Consumer blast radius

GitHub code search finds direct `js-bazel-package.yml` consumers in:

- Jesssullivan/scheduling-kit (`.github/workflows/ci.yml`, `.github/workflows/publish.yml`)
- Jesssullivan/scheduling-bridge (`.github/workflows/ci.yml`, `.github/workflows/publish.yml`)
- tinyland-inc/tinyvectors (`.github/workflows/ci.yml`, `.github/workflows/publish.yml`)

GloriousFlywheel also references the template in research/rollout docs, but not as a direct workflow consumer in the code-search result.

## Validation

- ruby YAML parse for reusable workflows
- actionlint via nix shell nixpkgs#actionlint
- git diff --check
- extracted workflow helper smoke: generate helper, source it, run a trivial command through run_with_bazel_fetch_retry

Refs: ci-templates#16, TIN-558, TIN-557

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the existing Bazel fetch retry logic from the "Validate Bazel targets" step into a reusable shell helper (`run_with_bazel_fetch_retry`) that is now applied to all eight consumer-supplied command steps (prepare, metadata, lint, typecheck, unit, integration, build, package surface). Consumer commands are now passed via step-level `env: COMMAND:` rather than direct template expansion, and `BAZEL_FETCH_RETRY_ATTEMPTS`/`NODE_VERSION` are promoted to the job-level `env` block, which is a clean simplification.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no regressions introduced; the refactoring is mechanically consistent across all eight steps and the heredoc/YAML indentation resolves correctly.

No P0 or P1 findings. All new run blocks carry shell: bash and set -euo pipefail; variable expansions are properly quoted; the BASH heredoc terminator lands at column 0 after YAML block-scalar stripping; printf '%q' correctly addresses the array-quoting concern from the previous thread; no new unpinned third-party actions are introduced.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Extracts retry logic into a reusable shell helper sourced by all consumer-command steps; correctly moves BAZEL_FETCH_RETRY_ATTEMPTS/NODE_VERSION to job-level env; uses env: vars for consumer commands instead of direct template expansion; all new run blocks have shell: bash and set -euo pipefail; bazel targets now quoted via printf '%q' (addressing the previous thread). |
| README.md | Prose updated to reflect that retry coverage now extends to all consumer-supplied validation commands, not just the explicit Bazel validation step. |
| docs/js-bazel-package.md | Documentation updated to match expanded retry scope; no technical issues. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: preserve Bazel target quoting in ret..."](https://github.com/tinyland-inc/ci-templates/commit/9bac5a889cb17e02dc1e772cb95c9df9b515a079) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29732477)</sub>

<!-- /greptile_comment -->