### PR TITLE
fix(bazel): authenticate private module tarball fetches

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -120,6 +120,15 @@ on:
       NPM_TOKEN:
         description: "npmjs.com publish token"
         required: false
+      TINYLAND_REGISTRY_GITHUB_TOKEN:
+        description: "GitHub token with read access to private tinyland-inc Bazel module tarballs"
+        required: false
+      SYNC_PAT:
+        description: "Fallback GitHub token with read access to sibling tinyland-inc repositories"
+        required: false
+      GH_TOKEN:
+        description: "Fallback GitHub CLI token with read access to sibling tinyland-inc repositories"
+        required: false
 
 jobs:
   resolve-runner:
@@ -377,6 +386,67 @@ jobs:
           }
           BASH
           echo "BAZEL_FETCH_RETRY_HELPER=$helper_path" >> "$GITHUB_ENV"
+
+      - name: Install Bazel GitHub credential helper
+        shell: bash
+        env:
+          TINYLAND_REGISTRY_GITHUB_TOKEN: ${{ secrets.TINYLAND_REGISTRY_GITHUB_TOKEN || secrets.SYNC_PAT || secrets.GH_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+
+          helper_path="$RUNNER_TEMP/js-bazel-package-github-credential-helper"
+          cat > "$helper_path" <<'BASH'
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          if [ "${1:-}" != "get" ]; then
+            echo "unsupported credential helper command: ${1:-<missing>}" >&2
+            exit 1
+          fi
+
+          request_json="$(cat)"
+          REQUEST_JSON="$request_json" python3 - <<'PY'
+          import json
+          import os
+
+          try:
+              request = json.loads(os.environ.get("REQUEST_JSON") or "{}")
+          except json.JSONDecodeError:
+              request = {}
+
+          uri = str(request.get("uri") or "")
+          token = (
+              os.environ.get("TINYLAND_REGISTRY_GITHUB_TOKEN")
+              or os.environ.get("GH_TOKEN")
+              or os.environ.get("GITHUB_TOKEN")
+              or ""
+          )
+
+          if token and (
+              uri.startswith("https://github.com/tinyland-inc/")
+              or uri.startswith("https://raw.githubusercontent.com/tinyland-inc/")
+          ):
+              print(json.dumps({"headers": {"Authorization": [f"Bearer {token}"]}}))
+          else:
+              print(json.dumps({"headers": {}}))
+          PY
+          BASH
+          chmod +x "$helper_path"
+
+          {
+            echo "common --credential_helper=github.com=$helper_path"
+            echo "common --credential_helper=raw.githubusercontent.com=$helper_path"
+          } >> user.bazelrc
+
+          if [ -n "${TINYLAND_REGISTRY_GITHUB_TOKEN:-}" ]; then
+            {
+              printf 'TINYLAND_REGISTRY_GITHUB_TOKEN=%s\n' "$TINYLAND_REGISTRY_GITHUB_TOKEN"
+              printf 'BAZEL_GITHUB_CREDENTIAL_HELPER=%s\n' "$helper_path"
+            } >> "$GITHUB_ENV"
+          else
+            echo "::warning::No GitHub token is available for private Bazel module tarball fetches."
+          fi
 
       - name: Prepare workspace
         if: ${{ inputs.prepare_command != '' }}


### PR DESCRIPTION
Adds a Bazel credential helper to the reusable JS Bazel package workflow so standalone package repos can fetch private tinyland-inc module tarballs from the Bazel registry during Bzlmod resolution.\n\nWhy:\n- Layer 1 package PRs are failing with GitHub archive 404s for existing private tags such as tinyland-content-types v0.2.3 and tinyland-calendar v0.2.3.\n- Bazel treats unauthenticated private GitHub archive fetches as 404; the tags exist.\n\nWhat changed:\n- Declares optional registry GitHub token secrets.\n- Installs a credential helper that emits Authorization headers for github.com/raw.githubusercontent.com tinyland-inc URLs.\n- Writes the helper into user.bazelrc, which the package repos already import.\n\nValidation:\n- YAML parses via Ruby Psych\n- git diff --check\n- extracted helper shell passes bash -n\n- helper returns an Authorization header for tinyland-inc GitHub archive URLs when token env is present

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Bazel credential helper step to the `validate` job that writes `Authorization: Bearer` headers for `github.com/tinyland-inc/` and `raw.githubusercontent.com/tinyland-inc/` URLs, fixing 404s during private module tarball fetches in Bzlmod resolution. Two P1 issues are present:

- The resolved token is persisted to `$GITHUB_ENV` without a preceding `::add-mask::` call, violating the team's secret-masking rule and risking exposure in any step that later dumps environment variables.
- The `|| github.token` tail in the fallback chain ensures the token env var is never empty, permanently suppressing the `::warning::` diagnostic intended to alert callers who haven't wired up a proper registry secret; those callers will silently receive a `github.token` that lacks cross-repo read access.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — two P1 defects: a missing secret mask and a fallback that silently swallows the "no token" diagnostic.

Two P1 findings on the single changed file pull the score below the P1 ceiling of 4. The mask omission is a current security-policy violation; the github.token fallback is a present logic defect that hides auth misconfiguration from callers.

.github/workflows/js-bazel-package.yml — specifically the new "Install Bazel GitHub credential helper" step.

<details open><summary><h3>Security Review</h3></summary>

- **Secret exposed without masking** (`.github/workflows/js-bazel-package.yml`, lines 442–446): The resolved GitHub token is written to `$GITHUB_ENV` without a prior `::add-mask::` call, meaning any subsequent step that prints environment variables could leak the raw token value in workflow logs.
- **`github.token` as silent fallback**: The fallback chain `|| github.token` at line 393 ensures the token env var is never empty, so the \"no token available\" guard never fires. Callers without a dedicated registry secret silently inject a token that lacks cross-repo access, and no warning surfaces to aid diagnosis.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Adds a Bazel GitHub credential helper step to the validate job — two P1 issues: the resolved token is written to $GITHUB_ENV without ::add-mask::, and the github.token fallback silences the intended "no token" diagnostic warning. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 442-446

Comment:
**Missing `::add-mask::` before persisting token to `$GITHUB_ENV`**

The resolved token value is written to `$GITHUB_ENV` without first calling `echo "::add-mask::<value>"`. Any later step that dumps environment variables (e.g. debug output, third-party actions) will expose the raw token in logs. The team rule explicitly requires masking when passing secret values between steps.

Add `echo "::add-mask::${TINYLAND_REGISTRY_GITHUB_TOKEN}"` as the first line inside the `if [ -n ... ]` block, before the `printf` calls that persist the value.

**Context Used:** This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 393

Comment:
**`github.token` fallback silences the "no-token" diagnostic**

`github.token` is always populated, so the step-level env var is never empty. The guard at the bottom of this step (`if [ -n "${TINYLAND_REGISTRY_GITHUB_TOKEN:-}" ]`) therefore always passes, and the `::warning::` intended to alert callers who haven't configured registry secrets will never fire. Worse, a caller without the dedicated token secrets will silently inject `github.token`, which has no cross-repo read access to other private `tinyland-inc` repositories; Bazel will receive a 401/403 with no actionable diagnostic.

Drop the `|| github.token` tail from the fallback chain so the warning actually fires when no registry token is wired up.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(bazel): authenticate private module ..."](https://github.com/tinyland-inc/ci-templates/commit/edf11fb31f29f9b38e4cdca0bf14fa85b49b8019) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29912181)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))

<!-- /greptile_comment -->