### PR TITLE
fix(js-bazel-package): publish bazel artifacts on tags

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -116,6 +116,10 @@ on:
         description: "When true, publish jobs only perform dry-runs"
         type: boolean
         default: true
+      publish_on_tag:
+        description: "When true, publish jobs run on push tag events even when dry_run remains true for PRs and branches"
+        type: boolean
+        default: false
     secrets:
       NPM_TOKEN:
         description: "npmjs.com publish token"
@@ -628,12 +632,14 @@ jobs:
     needs:
       - resolve-runner
       - validate
-    if: ${{ inputs.dry_run == false }}
+    if: ${{ inputs.dry_run == false || (inputs.publish_on_tag == true && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) }}
     runs-on: ${{ fromJson(needs.resolve-runner.outputs.publish_runner_labels_json) }}
     timeout-minutes: 20
     steps:
       - name: Validate publish contract
         shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           case "${{ inputs.publish_mode }}" in
@@ -643,6 +649,10 @@ jobs:
               exit 1
               ;;
           esac
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN is required for npmjs publication." >&2
+            exit 1
+          fi
 
       - name: Configure self-hosted cache contract
         if: ${{ runner.environment != 'github-hosted' }}
@@ -688,7 +698,7 @@ jobs:
     needs:
       - resolve-runner
       - validate
-    if: ${{ inputs.github_package_name != '' && inputs.dry_run == false }}
+    if: ${{ inputs.github_package_name != '' && (inputs.dry_run == false || (inputs.publish_on_tag == true && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))) }}
     runs-on: ${{ fromJson(needs.resolve-runner.outputs.publish_runner_labels_json) }}
     timeout-minutes: 20
     steps:

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -89,6 +89,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -113,12 +114,20 @@ jobs:
       package_dir: ./bazel-bin/pkg
       github_package_name: "@jesssullivan/scheduling-kit"
       dry_run: true
+      publish_on_tag: true
     secrets: inherit
 ```
 
 ## Example: hosted template consumer
 
 ```yaml
+on:
+  push:
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
 jobs:
   package:
     uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@main
@@ -133,6 +142,7 @@ jobs:
       bazel_targets: "//:pkg"
       package_dir: ./bazel-bin/pkg
       dry_run: true
+      publish_on_tag: true
 ```
 
 ## Notes
@@ -151,6 +161,11 @@ jobs:
   failures are not retried.
 - `publish_mode=hosted_exception` intentionally overrides the selected runner
   lane for publish jobs and uses `ubuntu-latest`.
+- `dry_run: true` keeps pull requests and branch pushes in validation-only mode.
+  Set `publish_on_tag: true` in package repositories that should publish the
+  Bazel artifact when the caller workflow is triggered by a `push` to `refs/tags/v*`.
+  The caller workflow must include an `on.push.tags` trigger, and npmjs
+  publication still requires `secrets.NPM_TOKEN`.
 - self-hosted jobs now call `nix-setup`, so Attic and Bazel cache hints are
   explicit instead of incidental runner state.
 - `workspace_mode=isolated` is the preferred contract for downstream pilots.


### PR DESCRIPTION
## Summary
- add explicit `publish_on_tag` opt-in to `js-bazel-package.yml`
- keep PR and branch validation dry-run by default while allowing real publishes on `push` tag events
- fail npm publish early with a clear `NPM_TOKEN` contract error
- document the caller-side `on.push.tags: ['v*']` requirement

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/js-bazel-package.yml"); YAML.load_file(".github/workflows/npm-publish.yml"); puts "yaml ok"'`
- `git diff --check`
- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/js-bazel-package.yml`

## Linear
- TIN-713

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `publish_on_tag` boolean input to `js-bazel-package.yml` that lets callers keep `dry_run: true` for PRs and branches while enabling real npm and GitHub Packages publishes on `push` tag events; it also adds an early `NPM_TOKEN` contract check and documents the pattern in the workflow's reference doc.

- **Missing `permissions` block on `publish-npm`**: `npm_publish_provenance` defaults to `true`, which requests an OIDC token for npm provenance; without `id-token: write` declared at the job level the OIDC call will fail on hosted runners, causing the publish to error. A `permissions:` block with `id-token: write` and `contents: read` should be added.
- **Blast-radius disclosure**: The review rules require PR descriptions to list which downstream repos consume a changed reusable workflow; the PR description omits this list (the docs reference `@tummycrypt/scheduling-kit`, `@tummycrypt/tinyvectors`, and `@tummycrypt/scheduling-bridge` but they are not enumerated in the PR body).

<h3>Confidence Score: 3/5</h3>

Hold — npm provenance will silently fail on hosted-runner tag publishes until a permissions block is added to publish-npm.

One P1 finding (missing id-token: write permission required for npm provenance on the newly-enabled tag publish path) pulls the score below the P1 ceiling of 4; the additional blast-radius disclosure gap is P2 but the P1 is the controlling factor.

.github/workflows/js-bazel-package.yml — publish-npm job needs an explicit permissions block.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Adds publish_on_tag input and expands job-level if-conditions to allow real publishes on tag events; adds NPM_TOKEN contract validation — but publish-npm still lacks a permissions block required for npm provenance (id-token: write). |
| docs/js-bazel-package.md | Adds on.push.tags trigger to both examples, publish_on_tag: true to both callers, and a new Notes entry documenting the dry_run / publish_on_tag interaction — all accurate and clear. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/js-bazel-package.yml`, line 631-638 ([link](https://github.com/tinyland-inc/ci-templates/blob/49bc5221407022b39adc70cce8c982f5f0964ef8/.github/workflows/js-bazel-package.yml#L631-L638)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing `permissions` block on publish-npm job**

   The `publish-npm` job has no explicit `permissions` block, which is required by the repository's review rules ("Use `permissions` blocks at the job level"). This matters concretely: `npm_publish_provenance` defaults to `true`, and requesting an OIDC token for npm provenance requires `id-token: write`. Without that declaration the OIDC token request will fail at publish time on hosted runners, causing `npm publish --provenance` to error. This path is now reachable via the new tag trigger, making the gap more prominent.

   ```yaml
   publish-npm:
     needs:
       - resolve-runner
       - validate
     if: ${{ inputs.dry_run == false || (inputs.publish_on_tag == true && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) }}
     runs-on: ${{ fromJson(needs.resolve-runner.outputs.publish_runner_labels_json) }}
     timeout-minutes: 20
     permissions:
       id-token: write   # required for npm provenance on hosted runners
       contents: read
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/js-bazel-package.yml
   Line: 631-638

   Comment:
   **Missing `permissions` block on publish-npm job**

   The `publish-npm` job has no explicit `permissions` block, which is required by the repository's review rules ("Use `permissions` blocks at the job level"). This matters concretely: `npm_publish_provenance` defaults to `true`, and requesting an OIDC token for npm provenance requires `id-token: write`. Without that declaration the OIDC token request will fail at publish time on hosted runners, causing `npm publish --provenance` to error. This path is now reachable via the new tag trigger, making the gap more prominent.

   ```yaml
   publish-npm:
     needs:
       - resolve-runner
       - validate
     if: ${{ inputs.dry_run == false || (inputs.publish_on_tag == true && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) }}
     runs-on: ${{ fromJson(needs.resolve-runner.outputs.publish_runner_labels_json) }}
     timeout-minutes: 20
     permissions:
       id-token: write   # required for npm provenance on hosted runners
       contents: read
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 631-638

Comment:
**Missing `permissions` block on publish-npm job**

The `publish-npm` job has no explicit `permissions` block, which is required by the repository's review rules ("Use `permissions` blocks at the job level"). This matters concretely: `npm_publish_provenance` defaults to `true`, and requesting an OIDC token for npm provenance requires `id-token: write`. Without that declaration the OIDC token request will fail at publish time on hosted runners, causing `npm publish --provenance` to error. This path is now reachable via the new tag trigger, making the gap more prominent.

```yaml
publish-npm:
  needs:
    - resolve-runner
    - validate
  if: ${{ inputs.dry_run == false || (inputs.publish_on_tag == true && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) }}
  runs-on: ${{ fromJson(needs.resolve-runner.outputs.publish_runner_labels_json) }}
  timeout-minutes: 20
  permissions:
    id-token: write   # required for npm provenance on hosted runners
    contents: read
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(js-bazel-package): publish bazel art..."](https://github.com/tinyland-inc/ci-templates/commit/49bc5221407022b39adc70cce8c982f5f0964ef8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29945348)</sub>

**Context used:**

- Context used - This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))

<!-- /greptile_comment -->