### PR TITLE
fix(js-bazel-package): allow GitHub Packages token override

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -124,6 +124,9 @@ on:
       NPM_TOKEN:
         description: "npmjs.com publish token"
         required: false
+      GITHUB_PACKAGES_TOKEN:
+        description: "Optional GitHub Packages token with write:packages for existing granular packages that do not grant GITHUB_TOKEN workflow access"
+        required: false
       TINYLAND_REGISTRY_GITHUB_TOKEN:
         description: "GitHub token with read access to private tinyland-inc Bazel module tarballs"
         required: false
@@ -704,6 +707,8 @@ jobs:
     steps:
       - name: Validate publish contract
         shell: bash
+        env:
+          GITHUB_PACKAGES_TOKEN_PRESENT: ${{ secrets.GITHUB_PACKAGES_TOKEN != '' }}
         run: |
           set -euo pipefail
           case "${{ inputs.publish_mode }}" in
@@ -713,6 +718,11 @@ jobs:
               exit 1
               ;;
           esac
+          if [ "$GITHUB_PACKAGES_TOKEN_PRESENT" = "true" ]; then
+            echo "Using GITHUB_PACKAGES_TOKEN for GitHub Packages publication."
+          else
+            echo "Using workflow GITHUB_TOKEN for GitHub Packages publication."
+          fi
 
       - name: Configure self-hosted cache contract
         if: ${{ runner.environment != 'github-hosted' }}
@@ -765,6 +775,6 @@ jobs:
       - name: Publish GitHub Packages artifact
         shell: bash
         env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_PACKAGES_TOKEN || github.token }}
           NPM_ACCESS: ${{ inputs.npm_access || 'public' }}
         run: npm publish "$PUBLISH_ROOT/pkg-github" --access "$NPM_ACCESS" --ignore-scripts


### PR DESCRIPTION
## Summary
- add optional `GITHUB_PACKAGES_TOKEN` to the reusable JS Bazel package workflow
- use it for GitHub Packages publication when provided, otherwise keep the normal workflow `GITHUB_TOKEN` path
- log which token source is selected without printing token values

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/js-bazel-package.yml")'`
- `git diff --check`
- `nix run nixpkgs#actionlint -- .github/workflows/js-bazel-package.yml`

## Context
This keeps the default repo-token flow intact, but gives the publish lane an explicit escape hatch for existing GitHub Packages with granular permissions that deny `GITHUB_TOKEN` writes until package Actions access is repaired.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional `GITHUB_PACKAGES_TOKEN` secret to the `publish-github` job in the reusable JS Bazel package workflow, falling back to `github.token` when the override is absent. The token-presence check and logging are implemented safely (boolean flag only, no value exposed), and the `||` fallback in the `NODE_AUTH_TOKEN` env expression behaves correctly for unset secrets.

One process-level concern: the repo rule requires PR descriptions for reusable workflow changes to list which downstream repos consume the workflow, so blast-radius reviewers can assess impact. That list is absent from this description.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only finding is a P2 masking best-practice and a missing consumer list in the PR description.

No P0/P1 defects found. A single P2 (missing explicit ::add-mask:: per repo policy) and a PR-description process gap keep this from a clean 5.

.github/workflows/js-bazel-package.yml — review the publish-github job's token handling step.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Adds optional `GITHUB_PACKAGES_TOKEN` secret to the publish-github job; token selection logic and presence-logging are safe, but explicit `::add-mask::` is missing per repo policy. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 775-780

Comment:
**Explicit `::add-mask::` missing for conditionally-selected token**

The repo rule requires `::add-mask::` when passing secret values, even though GitHub Actions does content-based auto-masking for `secrets.*`. Because `NODE_AUTH_TOKEN` can hold either `GITHUB_PACKAGES_TOKEN` or the implicit `github.token`, adding an explicit mask step before the publish step is belt-and-suspenders against any intermediate tooling (e.g., a future wrapper or debug mode) that prints env vars.

```yaml
      - name: Mask publish token
        shell: bash
        env:
          _TOKEN: ${{ secrets.GITHUB_PACKAGES_TOKEN || github.token }}
        run: |
          set -euo pipefail
          echo "::add-mask::$_TOKEN"
```

Then reference `_TOKEN` (or the same expression) in the publish step as `NODE_AUTH_TOKEN`.

**Context Used:** This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(js-bazel-package): allow package pub..."](https://github.com/tinyland-inc/ci-templates/commit/0ff58f561036396a399f8b19a6bb3f67b2d86904) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29948067)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))

<!-- /greptile_comment -->