### PR TITLE
docs: clarify github package owner scope

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -105,7 +105,7 @@ on:
         type: string
         default: "https://registry.npmjs.org"
       github_package_name:
-        description: "Optional full package name to use for GitHub Packages dry-runs/publication"
+        description: "Optional GitHub Packages package name; scope must match the GitHub owner, not necessarily the npmjs scope"
         type: string
         default: ""
       github_package_registry:

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -81,6 +81,16 @@ Meaning:
   - validate on the chosen runner class
   - publish from `ubuntu-latest` intentionally after artifact handoff
 
+### `github_package_name`
+
+`github_package_name` is the package coordinate used only for the GitHub
+Packages artifact. It may intentionally differ from the npmjs package name.
+
+GitHub Packages npm scopes are owner-bound, so the scope must match the GitHub
+account or organization that owns the package. For a `tinyland-inc/*` repository
+whose public npm package is `@tummycrypt/tinyland-auth`, use a GitHub Packages
+mirror name such as `@tinyland-inc/tinyland-auth`.
+
 ## Example: repo-owned self-hosted package path
 
 ```yaml


### PR DESCRIPTION
Clarifies that `github_package_name` is the GitHub Packages coordinate and must use the GitHub owner scope, which may differ from the public npmjs scope.\n\nTracking: TIN-713

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR updates the `github_package_name` input description in the reusable workflow and adds a new documentation section clarifying that the npm scope must match the GitHub org owner (e.g. `@tinyland-inc/`) rather than the public npmjs scope. No workflow logic is changed.

<h3>Confidence Score: 4/5</h3>

Safe to merge; purely documentation with a minor internal inconsistency in the example YAML.

Only P2 findings — the pre-existing example uses a personal-account scope that now contradicts the new guidance. No functional workflow changes.

docs/js-bazel-package.md — the `@jesssullivan/scheduling-kit` example should be updated to use the org scope consistent with the new guidance.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Description-only change to the `github_package_name` input; no functional behavior altered. |
| docs/js-bazel-package.md | Adds `github_package_name` section clarifying the owner-bound scope requirement, but the pre-existing example YAML uses a personal-account scope (`@jesssullivan/`) that contradicts the new guidance for `tinyland-inc/*` repos. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/js-bazel-package.md`, line 125 ([link](https://github.com/tinyland-inc/ci-templates/blob/69d7a4bef68334b6e2dc6eb7b564c036ae645bd4/docs/js-bazel-package.md#L125)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Example contradicts the new scope guidance**

   The new section (lines 84–93) states that for a `tinyland-inc/*` repository the GitHub Packages scope must match the GitHub owner (e.g. `@tinyland-inc/tinyland-auth`), but the existing example immediately below uses `@jesssullivan/scheduling-kit` — a personal account scope rather than the org scope. A reader following the example would set the wrong scope and contradict the rule that was just explained.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docs/js-bazel-package.md
   Line: 125

   Comment:
   **Example contradicts the new scope guidance**

   The new section (lines 84–93) states that for a `tinyland-inc/*` repository the GitHub Packages scope must match the GitHub owner (e.g. `@tinyland-inc/tinyland-auth`), but the existing example immediately below uses `@jesssullivan/scheduling-kit` — a personal account scope rather than the org scope. A reader following the example would set the wrong scope and contradict the rule that was just explained.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: docs/js-bazel-package.md
Line: 125

Comment:
**Example contradicts the new scope guidance**

The new section (lines 84–93) states that for a `tinyland-inc/*` repository the GitHub Packages scope must match the GitHub owner (e.g. `@tinyland-inc/tinyland-auth`), but the existing example immediately below uses `@jesssullivan/scheduling-kit` — a personal account scope rather than the org scope. A reader following the example would set the wrong scope and contradict the rule that was just explained.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: clarify github package owner scope"](https://github.com/tinyland-inc/ci-templates/commit/69d7a4bef68334b6e2dc6eb7b564c036ae645bd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30096619)</sub>

<!-- /greptile_comment -->