### PR TITLE
fix(js-bazel-package): use nonreserved packages token secret

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -124,7 +124,7 @@ on:
       NPM_TOKEN:
         description: "npmjs.com publish token"
         required: false
-      GITHUB_PACKAGES_TOKEN:
+      TINYLAND_GITHUB_PACKAGES_TOKEN:
         description: "Optional GitHub Packages token with write:packages for existing granular packages that do not grant GITHUB_TOKEN workflow access"
         required: false
       TINYLAND_REGISTRY_GITHUB_TOKEN:
@@ -708,7 +708,7 @@ jobs:
       - name: Validate publish contract
         shell: bash
         env:
-          GITHUB_PACKAGES_TOKEN_PRESENT: ${{ secrets.GITHUB_PACKAGES_TOKEN != '' }}
+          TINYLAND_GITHUB_PACKAGES_TOKEN_PRESENT: ${{ secrets.TINYLAND_GITHUB_PACKAGES_TOKEN != '' }}
         run: |
           set -euo pipefail
           case "${{ inputs.publish_mode }}" in
@@ -718,8 +718,8 @@ jobs:
               exit 1
               ;;
           esac
-          if [ "$GITHUB_PACKAGES_TOKEN_PRESENT" = "true" ]; then
-            echo "Using GITHUB_PACKAGES_TOKEN for GitHub Packages publication."
+          if [ "$TINYLAND_GITHUB_PACKAGES_TOKEN_PRESENT" = "true" ]; then
+            echo "Using TINYLAND_GITHUB_PACKAGES_TOKEN for GitHub Packages publication."
           else
             echo "Using workflow GITHUB_TOKEN for GitHub Packages publication."
           fi
@@ -775,6 +775,6 @@ jobs:
       - name: Publish GitHub Packages artifact
         shell: bash
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_PACKAGES_TOKEN || github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.TINYLAND_GITHUB_PACKAGES_TOKEN || github.token }}
           NPM_ACCESS: ${{ inputs.npm_access || 'public' }}
         run: npm publish "$PUBLISH_ROOT/pkg-github" --access "$NPM_ACCESS" --ignore-scripts


### PR DESCRIPTION
GitHub rejects custom Actions secret names starting with `GITHUB_`, so the previous `GITHUB_PACKAGES_TOKEN` override could not be installed as an org secret.\n\nThis switches the reusable workflow contract to `TINYLAND_GITHUB_PACKAGES_TOKEN` while preserving the fallback to the workflow `GITHUB_TOKEN`.\n\nValidation:\n- Ruby YAML parse\n- `git diff --check`\n\nTracking: TIN-713

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames the `GITHUB_PACKAGES_TOKEN` secret to `TINYLAND_GITHUB_PACKAGES_TOKEN` in the `js-bazel-package` reusable workflow to work around GitHub's restriction on org secrets starting with `GITHUB_`. The change is functionally correct for new consumers, but is a breaking contract change for existing ones.

- **Breaking change without deprecation**: Any downstream caller already passing `GITHUB_PACKAGES_TOKEN:` in their `secrets:` block will silently lose the token; the workflow falls back to `github.token`, which typically lacks `write:packages` for granular PAT scenarios — causing silent publish failures. The repo rules require a deprecation period or version bump for breaking changes to the workflow contract.
- **Downstream consumers not listed**: The PR description does not enumerate which repos consume this workflow, as required by the blast-radius policy for changes to reusable workflows.

<h3>Confidence Score: 3/5</h3>

Not safe to merge without a compatibility shim or explicit confirmation that no downstream caller uses the old secret name.

One P1: the secret rename silently breaks downstream callers that pass the old `GITHUB_PACKAGES_TOKEN` — they fall back to `github.token` with no error, causing publish failures. Additionally, PR description omits the required downstream consumer list. P1 ceiling is 4/5; the blast-radius risk and silent-failure mode pull the score to 3/5.

.github/workflows/js-bazel-package.yml — the secret contract rename

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Renames the `GITHUB_PACKAGES_TOKEN` secret to `TINYLAND_GITHUB_PACKAGES_TOKEN` throughout — a breaking contract change that silently degrades downstream callers still passing the old secret name. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 127-129

Comment:
**Breaking secret contract change without deprecation**

Renaming the secret from `GITHUB_PACKAGES_TOKEN` to `TINYLAND_GITHUB_PACKAGES_TOKEN` is a breaking change to the workflow's external contract. Any downstream caller that already passes `GITHUB_PACKAGES_TOKEN:` in their `secrets:` block will silently stop forwarding the token — the workflow falls back to `github.token`, which typically lacks `write:packages` for granular package PAT scenarios. The custom rules require a deprecation period or version bump for breaking changes to workflow inputs/outputs (secrets are part of that contract). Consider accepting both secret names with a fallback, e.g. `${{ secrets.TINYLAND_GITHUB_PACKAGES_TOKEN || secrets.GITHUB_PACKAGES_TOKEN || github.token }}`, during a transition window.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(js-bazel-package): use nonreserved p..."](https://github.com/tinyland-inc/ci-templates/commit/546f03eb8d4b1e72710802480782e2e59cd2dbfe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30101913)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->