### PR TITLE
fix(js-bazel-package): skip duplicate package publishes

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -686,12 +686,24 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_ACCESS: ${{ inputs.npm_access || 'public' }}
+          NPM_REGISTRY_URL: ${{ inputs.npm_registry_url || 'https://registry.npmjs.org' }}
           PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
           RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           set -euo pipefail
           PACKAGE_BASENAME=$(basename "$PACKAGE_DIR")
-          PUBLISH_ARGS=("$PUBLISH_ROOT/$PACKAGE_BASENAME" --ignore-scripts --access "$NPM_ACCESS")
+          PACKAGE_PATH="$PUBLISH_ROOT/$PACKAGE_BASENAME"
+          PACKAGE_JSON="$PACKAGE_PATH/package.json"
+          PACKAGE_NAME=$(node -e "const pkg=require(process.argv[1]); if (!pkg.name) process.exit(1); console.log(pkg.name)" "$PACKAGE_JSON")
+          PACKAGE_VERSION=$(node -e "const pkg=require(process.argv[1]); if (!pkg.version) process.exit(1); console.log(pkg.version)" "$PACKAGE_JSON")
+          PACKAGE_ID="${PACKAGE_NAME}@${PACKAGE_VERSION}"
+          if existing_version=$(npm view "$PACKAGE_ID" version --registry "$NPM_REGISTRY_URL" 2>/dev/null); then
+            if [ "$existing_version" = "$PACKAGE_VERSION" ]; then
+              echo "::notice::Skipping npmjs publish because $PACKAGE_ID already exists in $NPM_REGISTRY_URL."
+              exit 0
+            fi
+          fi
+          PUBLISH_ARGS=("$PACKAGE_PATH" --ignore-scripts --access "$NPM_ACCESS")
           if [ "${{ inputs.npm_publish_provenance }}" = "true" ] && [ "$RUNNER_ENVIRONMENT" != "self-hosted" ]; then
             PUBLISH_ARGS+=(--provenance)
           fi
@@ -776,5 +788,19 @@ jobs:
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.TINYLAND_GITHUB_PACKAGES_TOKEN || github.token }}
+          GITHUB_PACKAGE_REGISTRY: ${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}
           NPM_ACCESS: ${{ inputs.npm_access || 'public' }}
-        run: npm publish "$PUBLISH_ROOT/pkg-github" --access "$NPM_ACCESS" --ignore-scripts
+        run: |
+          set -euo pipefail
+          PACKAGE_PATH="$PUBLISH_ROOT/pkg-github"
+          PACKAGE_JSON="$PACKAGE_PATH/package.json"
+          PACKAGE_NAME=$(node -e "const pkg=require(process.argv[1]); if (!pkg.name) process.exit(1); console.log(pkg.name)" "$PACKAGE_JSON")
+          PACKAGE_VERSION=$(node -e "const pkg=require(process.argv[1]); if (!pkg.version) process.exit(1); console.log(pkg.version)" "$PACKAGE_JSON")
+          PACKAGE_ID="${PACKAGE_NAME}@${PACKAGE_VERSION}"
+          if existing_version=$(npm view "$PACKAGE_ID" version --registry "$GITHUB_PACKAGE_REGISTRY" 2>/dev/null); then
+            if [ "$existing_version" = "$PACKAGE_VERSION" ]; then
+              echo "::notice::Skipping GitHub Packages publish because $PACKAGE_ID already exists in $GITHUB_PACKAGE_REGISTRY."
+              exit 0
+            fi
+          fi
+          npm publish "$PACKAGE_PATH" --access "$NPM_ACCESS" --ignore-scripts

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -185,3 +185,9 @@ jobs:
   validation workspace stays in compatibility mode.
 - npmjs publication still requests provenance on hosted runners and skips it on
   self-hosted runners when needed.
+- real publish jobs are idempotent for already-published package versions. After
+  extracting the Bazel artifact, the npmjs and GitHub Packages jobs check
+  whether the exact `name@version` already exists in the target registry and
+  skip only that duplicate-version case. Registry lookup failures or absent
+  versions still fall through to `npm publish` so permission and package errors
+  remain visible.


### PR DESCRIPTION
## Summary
- skip npmjs publish when the Bazel artifact exact name@version already exists
- skip GitHub Packages publish when the rewritten package exact name@version already exists
- document the duplicate-version idempotence contract

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/js-bazel-package.yml\n\n## Notes\nThis keeps permission and absent-version failures visible: registry lookup failures fall through to npm publish, and only an exact existing version is skipped.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds idempotent publish guards to both the `publish-npm` and `publish-github` jobs: before calling `npm publish`, each step uses `npm view name@version version --registry …` to check whether that exact version already exists, and skips publication if it does. The implementation correctly follows repo shell conventions (`set -euo pipefail`, `shell: bash`, quoted variable expansions), uses already-declared workflow inputs, and keeps permission/absent-version failures visible by only catching a clean 0-exit from `npm view`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; only P2 style findings present.

No P0 or P1 issues found. The two P2 comments flag a redundant inner equality check that is always true and can be simplified, but it does not affect correctness or safety.

.github/workflows/js-bazel-package.yml — the redundant inner version-check pattern appears in both publish steps.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Adds idempotent publish guards to publish-npm and publish-github jobs; logic is sound and follows repo shell conventions, but the inner version-equality check is always true and can be simplified. |
| docs/js-bazel-package.md | Documentation-only addition that accurately describes the new duplicate-version idempotence contract; no issues found. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 700-705

Comment:
**Redundant inner version comparison**

`npm view "$PACKAGE_ID" version` only exits 0 when the pinned `name@version` exists and returns exactly `PACKAGE_VERSION` — so the inner `[ "$existing_version" = "$PACKAGE_VERSION" ]` guard is always true on the happy path and can never be false while the outer `if` succeeded. The dead branch could mislead future readers into thinking there's a case where the outer check passes but the version doesn't match.

```suggestion
          if npm view "$PACKAGE_ID" version --registry "$NPM_REGISTRY_URL" &>/dev/null; then
            echo "::notice::Skipping npmjs publish because $PACKAGE_ID already exists in $NPM_REGISTRY_URL."
            exit 0
          fi
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/js-bazel-package.yml
Line: 800-805

Comment:
**Same redundant inner comparison in GitHub Packages step**

Mirrors the same pattern as in `publish-npm`: `npm view name@version version` can only exit 0 when that exact version exists, so `existing_version` will always equal `PACKAGE_VERSION` inside the outer `if`. The inner check adds no protection and can be removed for clarity.

```suggestion
          if npm view "$PACKAGE_ID" version --registry "$GITHUB_PACKAGE_REGISTRY" &>/dev/null; then
            echo "::notice::Skipping GitHub Packages publish because $PACKAGE_ID already exists in $GITHUB_PACKAGE_REGISTRY."
            exit 0
          fi
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(js-bazel-package): skip duplicate pa..."](https://github.com/tinyland-inc/ci-templates/commit/1e696ed2490bb13dcddc30d991f723372b852208) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30128386)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->