### PR TITLE
fix(js-bazel-package): tolerate duplicate dry-run versions

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -584,7 +584,18 @@ jobs:
         run: |
           set -euo pipefail
           cd "$WORKSPACE_DIR"
-          npm publish --dry-run --ignore-scripts --access "$NPM_ACCESS" "$PACKAGE_DIR"
+          set +e
+          dry_run_output="$(npm publish --dry-run --ignore-scripts --access "$NPM_ACCESS" "$PACKAGE_DIR" 2>&1)"
+          dry_run_status="$?"
+          set -e
+          printf '%s\n' "$dry_run_output"
+          if [ "$dry_run_status" -ne 0 ]; then
+            if grep -Fq "You cannot publish over the previously published versions" <<<"$dry_run_output"; then
+              echo "::notice::Skipping npm publish dry-run because this exact package version already exists in npm."
+            else
+              exit "$dry_run_status"
+            fi
+          fi
 
       - name: Validate GitHub Packages dry-run from Bazel artifact
         if: ${{ inputs.github_package_name != '' }}
@@ -691,6 +702,7 @@ jobs:
           RUNNER_ENVIRONMENT: ${{ runner.environment }}
         run: |
           set -euo pipefail
+          : "${PACKAGE_DIR:?}"
           PACKAGE_BASENAME=$(basename "$PACKAGE_DIR")
           PACKAGE_PATH="$PUBLISH_ROOT/$PACKAGE_BASENAME"
           PACKAGE_JSON="$PACKAGE_PATH/package.json"

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -191,3 +191,7 @@ jobs:
   skip only that duplicate-version case. Registry lookup failures or absent
   versions still fall through to `npm publish` so permission and package errors
   remain visible.
+- npm publish dry-run validation also treats npm's duplicate-version rejection
+  as an idempotent pass. Newer npm versions may reject `npm publish --dry-run`
+  for an already-published version even though the preceding `npm pack`
+  validation proved the package artifact shape.


### PR DESCRIPTION
## Summary
- treat npm publish dry-run duplicate-version rejection as an idempotent validation pass
- keep other npm dry-run failures visible
- satisfy actionlint/shellcheck by asserting PACKAGE_DIR in the publish step
- document why this matters for already-published package versions on newer npm

## Validation
- `git diff --check`
- `nix run nixpkgs#actionlint -- .github/workflows/js-bazel-package.yml`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the `npm publish --dry-run` validation step tolerant of duplicate-version rejections from newer npm versions, mirroring the idempotency already present in the real `publish-npm` job. It also adds a defensive `PACKAGE_DIR` assertion in the publish step to satisfy actionlint/shellcheck, and updates the docs to explain the rationale. The shell error-capture pattern (`set +e` / capture `$?` / `set -e`) is correct, all steps retain `shell: bash` and `set -euo pipefail`, and no secrets are exposed in logs.

<h3>Confidence Score: 4/5</h3>

Safe to merge; one P2 fragility around the hardcoded npm error string, no blocking issues

Only P2 findings present; the core error-capture logic is correct, shell rules are followed, and no security or correctness regressions are introduced

.github/workflows/js-bazel-package.yml — the grep-based npm error message match at line 593

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Adds duplicate-version tolerance to the npm dry-run step via set+e / grep pattern; shell hygiene and error propagation are correct, but the hardcoded npm error string is fragile |
| docs/js-bazel-package.md | Documentation-only addition explaining the idempotent dry-run behaviour; no issues |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/js-bazel-package.yml:593
**Hardcoded npm error message is fragile**

The grep match on `"You cannot publish over the previously published versions"` is tied to npm's current error wording. If npm changes this message in a future release the check silently passes through, making the `else` branch unreachable and swallowing any real publish failure. Additionally, if npm exits non-zero for *multiple* reasons at once (including the duplicate-version notice alongside another error), only the matching substring is checked and the secondary failure is silently dropped. Consider anchoring the skip on the exit code plus a version-existence check via `npm view` (as the real `publish-npm` job already does) instead of parsing stderr prose.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(js-bazel-package): tolerate duplicat..."](https://github.com/tinyland-inc/ci-templates/commit/4cbd9eef865235b4da0d3f358f8e1bfb0fcc21b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30419272)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->