### PR TITLE
Use Node 24 action runtimes

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -314,7 +314,7 @@ jobs:
             rm -rf -- "$path"
           done
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@fdbc4fdcf7d143a5d0a39e9a02e103b13e309024 # v6.0.4
         with:
           version: ${{ inputs.pnpm_version || '9' }}
 
@@ -636,7 +636,7 @@ jobs:
 
       - name: Upload Bazel package artifact
         if: ${{ matrix.node-version == (inputs.publish_node_version || '22') }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bazel-pkg
           path: ${{ env.WORKSPACE_DIR }}/bazel-pkg.tgz
@@ -678,7 +678,7 @@ jobs:
           registry-url: ${{ inputs.npm_registry_url || 'https://registry.npmjs.org' }}
 
       - name: Download Bazel package artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bazel-pkg
 
@@ -758,7 +758,7 @@ jobs:
           registry-url: ${{ inputs.github_package_registry || 'https://npm.pkg.github.com' }}
 
       - name: Download Bazel package artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bazel-pkg
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,13 +43,13 @@ jobs:
       matrix:
         node-version: ${{ fromJson(inputs.node-versions || '["20", "22"]') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.4
         with:
           version: ${{ inputs.pnpm-version || '9' }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -86,13 +86,13 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.4
         with:
           version: ${{ inputs.pnpm-version || '9' }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.publish-node-version || '22' }}
           registry-url: https://npm.pkg.github.com
@@ -118,13 +118,13 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.4
         with:
           version: ${{ inputs.pnpm-version || '9' }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.publish-node-version || '22' }}
           registry-url: ${{ inputs.registry-url || 'https://registry.npmjs.org' }}


### PR DESCRIPTION
## Summary

Updates reusable workflow action references to Node 24 runtime releases ahead of GitHub's JavaScript action runtime migration.

- `js-bazel-package`: bumps `pnpm/action-setup` to `v6.0.4`, `actions/upload-artifact` to `v7.0.1`, and `actions/download-artifact` to `v8.0.1` by pinned commit SHA
- `npm-publish`: bumps checkout/setup-node/pnpm setup tags to Node 24-capable releases

## Validation

- `ruby -e 'require "yaml"; %w[.github/workflows/js-bazel-package.yml .github/workflows/npm-publish.yml].each { |path| YAML.load_file(path); puts "#{path}: ok" }'`
- `git diff --check`

## Notes

This is the upstream fix for the Node.js 20 action deprecation annotation seen in downstream package workflows such as `tinyland-inc/tinyvectors`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates action runtimes to Node 24-capable releases across `js-bazel-package.yml` and `npm-publish.yml`. The `js-bazel-package.yml` changes are correct — all three bumped actions are pinned to full commit SHAs. However, `npm-publish.yml` uses floating version tags (`@v6`, `@v6.0.4`) for all nine action references, violating the repository's mandatory SHA-pinning policy and introducing a supply-chain risk for all downstream consumers.

<h3>Confidence Score: 3/5</h3>

Not safe to merge — `npm-publish.yml` leaves all action references on floating tags, violating the SHA-pinning policy.

A single P1 finding (floating tags across all jobs in `npm-publish.yml`) that violates an explicit security rule and affects all downstream consumers of the reusable workflow. The `js-bazel-package.yml` half of the PR is clean and correctly pinned.

`npm-publish.yml` requires all nine `uses:` lines to be replaced with full commit SHAs before merging.

<details open><summary><h3>Security Review</h3></summary>

- **Supply-chain / tag hijacking** (`npm-publish.yml`): All nine action `uses:` references were updated to floating version tags (`@v6`, `@v6.0.4`) instead of pinned commit SHAs. A floating tag can be silently force-pushed to a malicious commit, allowing arbitrary code execution in any downstream consumer of this reusable workflow. `js-bazel-package.yml` (updated in the same PR) correctly uses full commit SHAs and should serve as the template for fixing `npm-publish.yml`.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/js-bazel-package.yml | Correctly bumps `pnpm/action-setup`, `actions/upload-artifact`, and `actions/download-artifact` to Node 24-capable releases, all pinned to full commit SHAs with version comments. |
| .github/workflows/npm-publish.yml | Bumps `actions/checkout`, `pnpm/action-setup`, and `actions/setup-node` to newer versions, but all nine `uses:` references use floating tags (e.g. `@v6`, `@v6.0.4`) instead of pinned commit SHAs, violating the org-wide SHA-pinning rule. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/npm-publish.yml:46-52
**Floating tags violate SHA-pinning policy**

All action references in this file use floating version tags (`v6`, `v6.0.4`) rather than pinned commit SHAs. A tag can be force-pushed to a malicious commit at any time, making this a supply-chain risk. The `js-bazel-package.yml` file updated in this same PR demonstrates the correct approach (e.g., `pnpm/action-setup@fdbc4fdcf7d143a5d0a39e9a02e103b13e309024 # v6.0.4`). All nine `uses:` lines in this file — across the `build-and-test`, `publish-gpr`, and `publish-npm` jobs — need full commit SHAs.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: use Node 24 action runtimes"](https://github.com/tinyland-inc/ci-templates/commit/d61ed797f57462c7afd804339112de381f06b20e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30475809)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - This repo contains reusable GitHub Actions workflo... ([source](https://app.greptile.com/review/custom-context?memory=instruction-1))

<!-- /greptile_comment -->