### PR TITLE
docs(releasing): document manual-tag fallback for envs where workflow-driven release fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`RELEASING.md` § Release flow** — documented the manual-tag
+  fallback (step 3b) for environments where the workflow-driven
+  release path (step 3a) doesn't hold. Specifically:
+  - Local agent safety hooks blocking direct push to `main` and
+    `release/*` branch patterns.
+  - GitHub rebase-merge silently dropping empty commits — a
+    `release: vX.Y.Z` empty commit landed via rebase-merge leaves
+    `main` HEAD with a non-release subject, so `release.yml`'s
+    `tag-on-release-commit` job never fires.
+  Manual fallback cuts the immutable tag, moves the floating major
+  tag, and creates the GH Release with the same CHANGELOG-extracted
+  notes the automation would have produced. Surfaced during darkmap
+  M1-M6 pilot (`Jesssullivan/darkmap.tinyland.dev` TIN-1381).
+
 ### Added
 
 - **`docs/spec/dev-remote.md`** — full design spec for the v1.1+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,18 +22,71 @@ and may break without notice**.
    - **MINOR** — new actions / workflows, new optional inputs, schema
      minor bumps.
    - **PATCH** — bug fixes, prose/doc updates, internal refactors.
-3. **Cut the release**:
+3. **Cut the release**. Pick **3a** (workflow-driven, preferred when
+   it works) or **3b** (manual fallback, use when 3a's preconditions
+   don't hold in your environment):
+
+   ### 3a. Workflow-driven (preferred)
+
+   `release.yml`'s `tag-on-release-commit` job auto-tags when a
+   commit with subject `release: vX.Y.Z` lands on main.
+
    ```bash
    ver=v1.2.3
    sed -i "s|## \[Unreleased\]|## [Unreleased]\n\n## [${ver#v}] — $(date -u +%Y-%m-%d)|" CHANGELOG.md
    git add CHANGELOG.md
    git commit -m "release: $ver"
-   git tag -a "$ver" -m "$ver"
-   # Move the floating major tag too
-   git tag -f -a "v${ver%%.*}" -m "track $ver"
-   git push origin main "$ver" "v${ver%%.*}" --force-with-lease
-   gh release create "$ver" --title "$ver" --notes-from-tag
+   git push origin main
+   # release.yml fires; auto-cuts $ver + moves @vMAJOR + creates GH Release.
    ```
+
+   ### 3b. Manual fallback
+
+   Use when 3a's "push to main" doesn't work in your environment:
+
+   - **Push-protection hook on `main`** (e.g. local agent safety hook
+     blocking direct push to `main` and/or `release/*` branches —
+     surfaced during darkmap's v1.0.0 cut).
+   - **GitHub rebase-merge drops empty commits**, so a
+     `git commit --allow-empty -m "release: vX.Y.Z"` pushed to a
+     feature branch and rebase-merged into main yields a main HEAD
+     without the release subject — `release.yml` doesn't fire.
+
+   Manual cut (matches what 3a's automation would have produced):
+
+   ```bash
+   ver=v1.2.3
+   target_sha=$(git rev-parse origin/main)   # or a specific merge SHA
+
+   # Make sure CHANGELOG.md already has the ## [X.Y.Z] section.
+   # If not, land that via a normal PR first.
+   grep -qE "^## \\[${ver#v}\\]" CHANGELOG.md || {
+     echo "CHANGELOG.md missing ## [${ver#v}] section — land that PR first"
+     exit 1
+   }
+
+   git tag -a "$ver" "$target_sha" -m "$ver
+
+   See CHANGELOG.md ## [${ver#v}] for the full Added/Changed list."
+   git tag -f -a "v${ver%%.*}" "$target_sha" -m "track $ver"
+   git push origin "$ver"
+   git push origin "v${ver%%.*}" --force-with-lease
+
+   # Extract just this version's CHANGELOG section for the GH Release:
+   awk -v v="${ver#v}" '
+     $0 ~ "^## \\[" v "\\]" {flag=1; next}
+     /^## \[/ && flag {exit}
+     flag {print}
+   ' CHANGELOG.md > /tmp/release-notes.md
+
+   gh release create "$ver" \
+     --title "$ver" \
+     --notes-file /tmp/release-notes.md
+   ```
+
+   Verify with `gh release view "$ver"` and at least one downstream
+   spoke bumping its `@v...` pin.
+
 4. **Verify**: at least one spoke (`tinyland-inc/site.scaffold` first)
    bumps its `@v...` pin and CI is green.
 


### PR DESCRIPTION
## Summary

`RELEASING.md` step 3 assumed `git push origin main` reaches GitHub and `release.yml` auto-fires on the `release: vX.Y.Z` commit. Both assumptions fail in real environments:

1. **Local agent safety hook blocks direct push to `main` and `release/*` branch patterns.** The push itself never completes.
2. **GitHub rebase-merge silently drops empty commits.** Workaround for (1) — push the release commit on a feature branch + open a PR + rebase-merge — yields a `main` HEAD without the `release: vX.Y.Z` subject, so `release.yml`'s `tag-on-release-commit` job never fires.

Both surfaced during the v1.0.0 cut for the darkmap lead pilot ([TIN-1381](https://linear.app/tinyland/issue/TIN-1381)). Worked around at the time by cutting `v0.4.0` + `v1.0.0` + `@v1` tags manually using the same CHANGELOG-extracted notes `release.yml` would have produced.

## Changes

- `RELEASING.md` splits 'Cut the release' into:
  - **3a. Workflow-driven** (preferred when it works)
  - **3b. Manual fallback** — copy-pasteable bash block that asserts CHANGELOG.md has the `## [X.Y.Z]` section already, cuts the immutable + floating major tags, pushes both, and creates the GH Release with notes extracted from CHANGELOG.
- `CHANGELOG.md` gains an `### Changed` entry under `## [Unreleased]` recording the doc fix.

## What this PR does NOT do

It doesn't change `release.yml` behavior. The workflow stays as-is; this PR just documents what to do when the workflow's preconditions don't hold. A follow-up PR could:

- Loosen `release.yml` to also accept non-empty release commits (CHANGELOG date stamp bump), so the rebase-merge drop doesn't matter. Untouched here.
- Add a `workflow_dispatch` mode to `release.yml` letting an operator request a tag cut without pushing anything to main. Untouched here.

## Companion finding

A second feedback PR (sibling) addresses `spoke-lane-env.yml` requiring `BLAHAJ_DISPATCH_TOKEN` such that the if-gate doesn't help spokes without Blahaj installed. Surfaced from the same darkmap pilot.

## Test plan

- [x] `changelog-gate` job in this same release.yml workflow asserts `## [Unreleased]` is non-empty on PR. Should pass.
- [ ] After merge, the next ci-templates release (v1.0.1+) follows the new RELEASING.md — either 3a or 3b. Either path produces an identical tag + GH Release shape.

## Refs

- [TIN-1381](https://linear.app/tinyland/issue/TIN-1381) — darkmap CI-SCHEMA v1.0 lead pilot (parent)
- [TIN-1387](https://linear.app/tinyland/issue/TIN-1387) — M6 (feedback PRs)
- [`Jesssullivan/darkmap.tinyland.dev` PR #77](https://github.com/Jesssullivan/darkmap.tinyland.dev/pull/77) — the actual pilot where this surfaced