### PR TITLE
feat(v1.1): spoke-fits-spokes — lane-env secret optional + spoke-ci runner_labels_json

### DIFF
--- a/.github/workflows/spoke-ci.yml
+++ b/.github/workflows/spoke-ci.yml
@@ -21,6 +21,24 @@ on:
       default_runner_class:
         type: string
         default: tinyland-nix
+        description: Single runner-class label for matrix jobs. Used when `runner_labels_json` is unset and lanes.json doesn't override per-lane.
+      runner_labels_json:
+        type: string
+        default: ""
+        description: |
+          Optional JSON-array expression evaluating to the runs-on labels
+          for matrix jobs. When set (non-empty), takes precedence over
+          `matrix.lane.runner_class` and `default_runner_class`. Enables
+          spokes with dynamic fallback patterns (e.g. graceful degradation
+          to `ubuntu-latest` when cluster labels aren't reachable) to
+          adopt the wrapper without losing their runner-routing logic.
+
+          Example value from the caller:
+            runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
+
+          The string must be a JSON array. The receiver runs
+          `${{ fromJSON(inputs.runner_labels_json) }}` when this input is
+          non-empty.
       gitleaks_config:
         type: string
         default: .gitleaks.toml
@@ -73,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         lane: ${{ fromJson(needs.lanes-load.outputs.lanes_json) }}
-    runs-on: ${{ matrix.lane.runner_class || inputs.default_runner_class }}
+    runs-on: ${{ inputs.runner_labels_json != '' && fromJSON(inputs.runner_labels_json) || matrix.lane.runner_class || inputs.default_runner_class }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
@@ -111,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         lane: ${{ fromJson(needs.lanes-load.outputs.lanes_json) }}
-    runs-on: ${{ matrix.lane.runner_class || inputs.default_runner_class }}
+    runs-on: ${{ inputs.runner_labels_json != '' && fromJSON(inputs.runner_labels_json) || matrix.lane.runner_class || inputs.default_runner_class }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/spoke-lane-env.yml
+++ b/.github/workflows/spoke-lane-env.yml
@@ -28,7 +28,13 @@ on:
         default: 0
     secrets:
       BLAHAJ_DISPATCH_TOKEN:
-        required: true
+        # required: false so spokes can keep `on: pull_request` enabled
+        # before Blahaj is installed on the repo. Internal early-exit
+        # below (`check-blahaj-token` job) gates the dispatch on token
+        # presence — empty token = whole pipeline skips cleanly. See
+        # https://github.com/Jesssullivan/darkmap.tinyland.dev/pull/82
+        # for the finding that drove this change.
+        required: false
       TAILSCALE_API_KEY:
         required: false
 
@@ -44,7 +50,31 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Early-exit gate. If BLAHAJ_DISPATCH_TOKEN is empty (Blahaj not yet
+  # installed on the calling spoke), `enabled=false` is emitted and
+  # every downstream job's `if:` short-circuits. The workflow shows
+  # green with all jobs skipped, NOT a parse-time failure.
+  check-blahaj-token:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      enabled: ${{ steps.probe.outputs.enabled }}
+    steps:
+      - id: probe
+        env:
+          TOKEN: ${{ secrets.BLAHAJ_DISPATCH_TOKEN }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::BLAHAJ_DISPATCH_TOKEN present; lane-env pipeline will run."
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::BLAHAJ_DISPATCH_TOKEN empty; lane-env pipeline skipping cleanly (no Blahaj integration yet)."
+          fi
+
   lanes-load:
+    needs: [check-blahaj-token]
+    if: needs.check-blahaj-token.outputs.enabled == 'true'
     runs-on: ubuntu-latest
     outputs:
       lanes_json: ${{ steps.load.outputs.lanes_json }}
@@ -62,8 +92,8 @@ jobs:
           path: ${{ inputs.lanes_path }}
 
   publish-image:
-    if: github.event.action != 'closed' && !inputs.reap
-    needs: [lanes-load]
+    if: needs.check-blahaj-token.outputs.enabled == 'true' && github.event.action != 'closed' && !inputs.reap
+    needs: [check-blahaj-token, lanes-load]
     strategy:
       fail-fast: false
       matrix:
@@ -99,8 +129,8 @@ jobs:
           echo "image_ref=${{ steps.imgref.outputs.image_ref }}" >> "$GITHUB_OUTPUT"
 
   dispatch-apply:
-    if: github.event.action != 'closed' && !inputs.reap
-    needs: [lanes-load, publish-image]
+    if: needs.check-blahaj-token.outputs.enabled == 'true' && github.event.action != 'closed' && !inputs.reap
+    needs: [check-blahaj-token, lanes-load, publish-image]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -121,8 +151,8 @@ jobs:
           dispatch_token: ${{ secrets.BLAHAJ_DISPATCH_TOKEN }}
 
   tailnet-qa:
-    if: github.event.action != 'closed' && !inputs.reap && inputs.enable_tailnet_qa
-    needs: [lanes-load, dispatch-apply]
+    if: needs.check-blahaj-token.outputs.enabled == 'true' && github.event.action != 'closed' && !inputs.reap && inputs.enable_tailnet_qa
+    needs: [check-blahaj-token, lanes-load, dispatch-apply]
     strategy:
       fail-fast: false
       matrix:
@@ -140,8 +170,8 @@ jobs:
           # This job exists to gate the per-lane `ci/lane/<name>` E2E status.
 
   destroy-lanes:
-    if: github.event.action == 'closed' || inputs.reap
-    needs: [lanes-load]
+    if: needs.check-blahaj-token.outputs.enabled == 'true' && (github.event.action == 'closed' || inputs.reap)
+    needs: [check-blahaj-token, lanes-load]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ### Changed
 
+- **`spoke-lane-env.yml` — `BLAHAJ_DISPATCH_TOKEN: required: false`** —
+  loosen the secret contract so spokes can keep the `pull_request:`
+  trigger enabled before Blahaj is installed on the repo. New
+  internal `check-blahaj-token` job runs first and gates every
+  downstream job's `if:` on token presence — empty token = whole
+  pipeline skips cleanly with a `::notice::`, NOT a workflow-file
+  parse failure.
+
+  Surfaced by darkmap M6 validation
+  ([test PR #82](https://github.com/Jesssullivan/darkmap.tinyland.dev/pull/82)):
+  GitHub resolves required secrets at workflow-call PARSE time,
+  before the job-level `if:` evaluates. So `required: true` +
+  empty caller secret = parse-time failure, and the gate never gets
+  a chance to short-circuit. Reversing to `required: false` lets the
+  job-level gate actually do its job. Backward-compatible: callers
+  that DO have the secret continue to work identically.
+
+### Added
+
+- **`spoke-ci.yml` — new `runner_labels_json` optional input** —
+  JSON-array expression evaluated via `fromJSON()` to set the
+  per-lane matrix jobs' `runs-on`. When set (non-empty), takes
+  precedence over `matrix.lane.runner_class` and
+  `default_runner_class`.
+
+  Enables spokes with dynamic runner-class fallback (e.g.
+  `runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}`)
+  to adopt the `spoke-ci.yml` wrapper without losing graceful
+  degradation when cluster labels aren't reachable.
+
+  Surfaced by darkmap M3 partial (TIN-1384). Without this input,
+  spokes with their own runner-routing logic (darkmap, MassageIthaca)
+  couldn't replace their hand-rolled `ci.yml` with the wrapper.
+  Now they can. Backward-compatible: existing callers that leave
+  this unset see no behavior change.
+
+## [1.0.1] — 2026-05-18
+
+### Changed
+
 - **`RELEASING.md` § Release flow** — documented the manual-tag
   fallback (step 3b) for environments where the workflow-driven
   release path (step 3a) doesn't hold. Specifically:


### PR DESCRIPTION
## Summary

Two backward-compatible spoke-friendliness fixes surfaced by the darkmap CI-SCHEMA v1.0 lead pilot ([TIN-1381](https://linear.app/tinyland/issue/TIN-1381)). Both ship as v1.1 (new input on spoke-ci.yml = SemVer minor bump).

## A. `spoke-lane-env.yml` — `BLAHAJ_DISPATCH_TOKEN: required: false`

**Finding from [darkmap test PR #82](https://github.com/Jesssullivan/darkmap.tinyland.dev/pull/82)**: the job-level `if:` gate doesn't help. GitHub resolves required secrets at workflow-call PARSE time, BEFORE the gate evaluates. Result: spokes without Blahaj installed got "workflow file issue" failures in 0 seconds on every PR, even when gating with `if: vars.BLAHAJ_LANE_ENV_ENABLED == 'true'`.

**Fix**:

- `required: true` → `required: false` on `BLAHAJ_DISPATCH_TOKEN`.
- New internal job `check-blahaj-token` runs first, probes `secrets.BLAHAJ_DISPATCH_TOKEN`, emits `outputs.enabled = true|false`.
- Every downstream job's `if:` gates on `needs.check-blahaj-token.outputs.enabled == 'true'`.
- Empty token = whole pipeline skips cleanly with a `::notice::`, NOT a parse failure.

**Backward compatibility**: callers that DO have the secret continue to work identically. New early-exit job adds ~5 seconds. No interface change for callers.

**Operator impact for darkmap**: lane-env.yml's `pull_request:` trigger can be re-enabled once this v1.1 lands. Currently commented out as the workaround.

## B. `spoke-ci.yml` — new `runner_labels_json` optional input

**Finding from darkmap M3 partial ([TIN-1384](https://linear.app/tinyland/issue/TIN-1384))**: darkmap's existing `ci.yml` has dynamic runner-class fallback via `runs-on: ${{ fromJSON(vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]') }}`. This graceful-degrades to `ubuntu-latest` when cluster labels aren't reachable. `spoke-ci.yml@v1.0.0` only supports a static `matrix.lane.runner_class` or static `default_runner_class` — no dynamic fallback. Replacing darkmap's ci.yml with the wrapper would lose graceful degradation.

**Fix**: optional `runner_labels_json` input. When set (non-empty), takes precedence:

```yaml
runs-on: ${{ inputs.runner_labels_json != '' && fromJSON(inputs.runner_labels_json)
           || matrix.lane.runner_class
           || inputs.default_runner_class }}
```

Both `flywheel-build` and `flywheel-test` matrix jobs updated.

**Caller usage**:

```yaml
jobs:
  ci:
    uses: tinyland-inc/ci-templates/.github/workflows/spoke-ci.yml@v1.1
    with:
      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
      flywheel_config: flywheel
    secrets: inherit
```

**Backward compatibility**: existing callers that leave the input unset see no behavior change.

**Operator impact**: spokes with sophisticated CI (darkmap, MassageIthaca) can now fully adopt the `spoke-ci.yml` wrapper. The darkmap M3 'PARTIAL' status (where ci.yml replacement was deferred) becomes 'FULL' once they pin `@v1.1.0` + pass their dynamic-fallback expression.

## Companion PRs (same darkmap pilot)

- [tinyland-inc/ci-templates #30](https://github.com/tinyland-inc/ci-templates/pull/30) — RELEASING.md manual-tag fallback (sibling docs PR).

## Migration

Backward-compatible. Both fixes are opt-in:

- **spoke-lane-env**: callers WITH Blahaj see no change. Callers WITHOUT Blahaj can now safely keep `pull_request:` trigger enabled.
- **spoke-ci**: callers happy with v1.0.0 static runner-class resolution leave `runner_labels_json` unset. Callers needing dynamic fallback (darkmap, MassageIthaca) opt in.

CHANGELOG.md `## [Unreleased]` documents both under `### Added` / `### Changed`.

## Test plan

- [x] YAML parses for both modified workflows.
- [ ] In a test caller, spoke-lane-env with no `BLAHAJ_DISPATCH_TOKEN` secret: `check-blahaj-token` notices + downstream jobs skip cleanly (not fail).
- [ ] In a test caller, spoke-lane-env with `BLAHAJ_DISPATCH_TOKEN` set: full pipeline runs as v1.0.0 behavior.
- [ ] In a test caller, spoke-ci with `runner_labels_json: '["ubuntu-latest"]'`: matrix jobs land on `ubuntu-latest`.
- [ ] In a test caller, spoke-ci with `runner_labels_json` unset: matrix jobs use the existing static resolution.

## SemVer

This release bumps to **v1.1.0**: new input on `spoke-ci.yml` is the SemVer minor trigger (additive, optional, non-breaking). The spoke-lane-env loosening could ship as v1.0.1 alone but bundles cleanly here.

## Refs

- [TIN-1381](https://linear.app/tinyland/issue/TIN-1381) — darkmap CI-SCHEMA v1.0 lead pilot (parent)
- [TIN-1384](https://linear.app/tinyland/issue/TIN-1384) — M3 (surfaced runner_labels_json need)
- [TIN-1387](https://linear.app/tinyland/issue/TIN-1387) — M6 (this PR is one of two feedback PRs)
- [`Jesssullivan/darkmap.tinyland.dev` PR #77](https://github.com/Jesssullivan/darkmap.tinyland.dev/pull/77) — the actual pilot

