### PR TITLE
fix(parse): v1.1.1 — strip expressions from spoke-ci description + remove if-skip from spoke-lane-env

### DIFF
--- a/.github/workflows/spoke-ci.yml
+++ b/.github/workflows/spoke-ci.yml
@@ -28,17 +28,13 @@ on:
         description: |
           Optional JSON-array expression evaluating to the runs-on labels
           for matrix jobs. When set (non-empty), takes precedence over
-          `matrix.lane.runner_class` and `default_runner_class`. Enables
+          matrix.lane.runner_class and default_runner_class. Enables
           spokes with dynamic fallback patterns (e.g. graceful degradation
-          to `ubuntu-latest` when cluster labels aren't reachable) to
+          to ubuntu-latest when cluster labels are not reachable) to
           adopt the wrapper without losing their runner-routing logic.
-
-          Example value from the caller:
-            runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON || '["ubuntu-latest"]' }}
-
-          The string must be a JSON array. The receiver runs
-          `${{ fromJSON(inputs.runner_labels_json) }}` when this input is
-          non-empty.
+          The string must be a JSON array. The receiver passes it
+          through fromJSON when non-empty. See README + the v1.1
+          release notes for an end-to-end caller example.
       gitleaks_config:
         type: string
         default: .gitleaks.toml

--- a/.github/workflows/spoke-lane-env.yml
+++ b/.github/workflows/spoke-lane-env.yml
@@ -158,7 +158,6 @@ jobs:
       matrix:
         lane: ${{ fromJson(needs.lanes-load.outputs.lanes_json) }}
     runs-on: tinyland-nix-kvm
-    if-skip: ${{ !matrix.lane.e2e }}
     steps:
       - uses: actions/checkout@v6
       - if: matrix.lane.e2e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`spoke-ci.yml` — strip literal `${{ ... }}` expressions from
+  `inputs.runner_labels_json.description`** — GitHub evaluates
+  `${{...}}` inside workflow-level `description:` text at PARSE time
+  and rejects expressions that reference contexts not available there
+  (`vars`, `secrets`, etc.). v1.1.0 shipped two example expressions
+  inside the description, which caused every caller to fail in 0
+  seconds with no jobs created. Replaced the embedded expressions with
+  plain-text guidance pointing to the README / release notes.
+- **`spoke-lane-env.yml` — remove invalid `if-skip:` job key on
+  `tailnet-qa`** — `if-skip` is not a valid GitHub Actions keyword.
+  Workflow parser rejects with `unexpected key "if-skip" for "job"
+  section`. The step-level `if: matrix.lane.e2e` on line 164 already
+  handles per-lane gating.
+
+Both bugs surfaced during darkmap M3-completion PR #86 (TIN-1398).
+Together they made v1.1.0 unusable for any spoke that calls
+`spoke-ci.yml@v1.1.0` or `spoke-lane-env.yml@v1.1.0` directly. Ships
+as v1.1.1.
+
 ### Changed
 
 - **`spoke-lane-env.yml` — `BLAHAJ_DISPATCH_TOKEN: required: false`** —


### PR DESCRIPTION
## Summary

v1.1.0 ships with two workflow-file parse errors that make every spoke caller fail at workflow_call time. Surfaced by darkmap M3-completion PR #86 (TIN-1398).

## Bug 1 — `spoke-ci.yml`: literal `${{ ... }}` in description block

Lines 37/40 of v1.1.0 embed example expressions inside `inputs.runner_labels_json.description: |`. GitHub Actions evaluates `${{...}}` inside `description:` text at workflow PARSE time and rejects expressions that reference contexts not available in that scope (`vars`, `secrets`). Diagnostic from `actionlint`:

```
spoke-ci-v1.1.0.yml:28:454: context "vars" is not allowed here.
no context is available here. [expression]
```

Fix: rephrased description to plain text, removed both `${{...}}` examples, pointed readers to README + release notes for caller examples.

## Bug 2 — `spoke-lane-env.yml`: invalid `if-skip:` job key

Line 161 uses `if-skip:` on the `tailnet-qa` job. Not a real GH Actions keyword. `actionlint`:

```
spoke-lane-env-v1.1.0.yml:161:5: unexpected key "if-skip" for "job"
section. expected one of "concurrency", "container", ... "if",
"name", ... [syntax-check]
```

Fix: removed the line. Step-level `if: matrix.lane.e2e` on line 164 already gates per-lane behavior.

## Impact on existing callers

v1.1.0 is **unusable** for any spoke that directly calls these reusable workflows. darkmap PR #86 hit 0-second failures with zero jobs created. Once v1.1.1 ships, callers re-pin `@v1.1.0` → `@v1.1.1`.

## Test plan

- [x] `actionlint .github/workflows/spoke-{ci,lane-env}.yml` clean (modulo self-hosted runner label warnings — pre-existing, unrelated).
- [ ] darkmap PR #86 caller re-pinned to `@v1.1.1` after merge + tag cut.
- [ ] Lane-env + CI workflows on PR #86 actually produce jobs (not 0-second parse failure).

## Refs

- [TIN-1398](https://linear.app/tinyland/issue/TIN-1398) — darkmap M3-completion (parent)
- [darkmap PR #86](https://github.com/Jesssullivan/darkmap.tinyland.dev/pull/86) — the canary that surfaced this

## SemVer

Ships as v1.1.1 (pure bugfix, behaviour-compatible).