### PR TITLE
fix(nix-install): v1.1.2 — setup-nix composite (detect-or-install) replaces cachix install

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,76 @@
+name: "Setup Nix (detect-or-install)"
+description: >
+  Composite that adds /nix/var/nix/profiles/default/bin + $HOME/.nix-profile/bin
+  to PATH, then probes for an existing Nix installation. If present, ensures
+  feature flags (nix-command + flakes) and exits. If absent, falls through to
+  DeterminateSystems/determinate-nix-action@v3.
+
+  Replaces direct use of cachix/install-nix-action@vN, which aborts with
+  "Aborting: Nix is already installed" when run on self-hosted runners that
+  have Nix preinstalled at /nix/var/nix/profiles/default/bin/nix — then
+  subsequent `nix develop` fails with "Permission denied" on the daemon lock
+  because the cachix action's setup steps didn't run to put the runner user
+  in the right group. Surfaced by darkmap PR #86 / TIN-1402.
+
+inputs:
+  extra_nix_config:
+    description: >
+      Extra newline-separated lines to append to nix.conf. Defaults to the
+      experimental-features line spokes need for `nix develop` + flakes.
+    required: false
+    default: |
+      experimental-features = nix-command flakes
+
+runs:
+  using: "composite"
+  steps:
+    - name: Add Nix to PATH
+      shell: bash
+      run: |
+        for nixbin in /nix/var/nix/profiles/default/bin "$HOME/.nix-profile/bin"; do
+          if [ -d "$nixbin" ]; then
+            echo "$nixbin" >> "$GITHUB_PATH"
+          fi
+        done
+
+    - name: Detect existing Nix
+      id: detect
+      shell: bash
+      run: |
+        set -euo pipefail
+        export PATH="/nix/var/nix/profiles/default/bin:$HOME/.nix-profile/bin:$PATH"
+        if command -v nix >/dev/null 2>&1; then
+          echo "installed=true" >> "$GITHUB_OUTPUT"
+          echo "::notice::Using preinstalled Nix at $(command -v nix)"
+        else
+          echo "installed=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::No Nix on PATH; will install via DeterminateSystems/determinate-nix-action."
+        fi
+
+    - name: Install Determinate Nix (if not preinstalled)
+      if: steps.detect.outputs.installed != 'true'
+      uses: DeterminateSystems/determinate-nix-action@v3
+      with:
+        extra-conf: ${{ inputs.extra_nix_config }}
+
+    - name: Ensure feature flags (preinstalled path)
+      if: steps.detect.outputs.installed == 'true'
+      shell: bash
+      env:
+        SETUP_NIX_EXTRA_CONFIG: ${{ inputs.extra_nix_config }}
+      run: |
+        set -euo pipefail
+        config_path="${HOME}/.config/nix/nix.conf"
+        mkdir -p "$(dirname "$config_path")"
+        touch "$config_path"
+        # Append each non-empty line from extra_nix_config that isn't already present.
+        # Per-user nix.conf is honored by single-user installs and by multi-user
+        # installs for the runner user. No sudo required.
+        while IFS= read -r line; do
+          [ -z "$line" ] && continue
+          if ! grep -Fxq -- "$line" "$config_path"; then
+            printf '%s\n' "$line" >> "$config_path"
+          fi
+        done <<< "$SETUP_NIX_EXTRA_CONFIG"
+        echo "::notice::Wrote per-user nix.conf at $config_path"
+        cat "$config_path"

--- a/.github/workflows/spoke-ci.yml
+++ b/.github/workflows/spoke-ci.yml
@@ -72,10 +72,7 @@ jobs:
       spoke_name: ${{ steps.load.outputs.spoke_name }}
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.2
       - id: load
         uses: tinyland-inc/ci-templates/.github/actions/lanes-load@v1.0.0
         with:
@@ -91,10 +88,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.2
 
       - name: Setup workspace
         run: nix develop --command just setup
@@ -129,10 +123,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.2
 
       - run: nix develop --command just setup
       - run: nix develop --command just check
@@ -143,10 +134,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.2
       - run: nix develop --command bazelisk mod graph
       - run: nix develop --command bazelisk build //:node_modules
 
@@ -161,9 +149,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.2
       - run: nix develop --command just setup
       - run: nix develop --command just test-e2e

--- a/.github/workflows/spoke-lane-env.yml
+++ b/.github/workflows/spoke-lane-env.yml
@@ -82,10 +82,7 @@ jobs:
       spoke_domain: ${{ steps.load.outputs.spoke_domain }}
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.2
       - id: load
         uses: tinyland-inc/ci-templates/.github/actions/lanes-load@v1.0.0
         with:
@@ -134,10 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.2
       - uses: tinyland-inc/ci-templates/.github/actions/lane-dispatch@v1.0.0
         with:
           pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
@@ -174,10 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.2
       - uses: tinyland-inc/ci-templates/.github/actions/lane-reap@v1.0.0
         with:
           pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`.github/actions/setup-nix/action.yml`** — new composite action that
+  detects an existing Nix installation (probes
+  `/nix/var/nix/profiles/default/bin` + `$HOME/.nix-profile/bin`,
+  then `command -v nix`). When Nix is preinstalled, adds it to PATH
+  and writes a per-user `~/.config/nix/nix.conf` with the requested
+  flags. When absent, falls through to
+  `DeterminateSystems/determinate-nix-action@v3`. Replaces all 8 use
+  sites of `cachix/install-nix-action@v31` in `spoke-ci.yml` (5) and
+  `spoke-lane-env.yml` (3).
+
+### Fixed
+
+- **All cachix/install-nix-action call sites** — the cachix action
+  aborts hard with `Aborting: Nix is already installed at /nix/var/nix/profiles/default/bin/nix`
+  on self-hosted runners that have Nix preinstalled (the case for
+  the Tinyland `tinyland-nix*` runner classes). Subsequent
+  `nix develop` then failed with `error: opening lock file "/nix/var/nix/db/big-lock": Permission denied`
+  because the runner user wasn't granted access to the daemon
+  database that the preinstalled multi-user nix relied on.
+  Surfaced by darkmap PR #86 / TIN-1402 (every flywheel-build and
+  flywheel-test matrix job failed in ~9 seconds).
+  Fix: route all callers through the new `setup-nix` composite,
+  which handles both the preinstalled-nix case and the
+  no-nix-installed case uniformly.
+
 ### Fixed
 
 - **`spoke-ci.yml` — strip literal `${{ ... }}` expressions from


### PR DESCRIPTION
## Problem (TIN-1402)

`cachix/install-nix-action@v31` aborts on self-hosted runners that have Nix preinstalled — the case for Tinyland's `tinyland-nix*` runner classes:

```
Aborting: Nix is already installed at /nix/var/nix/profiles/default/bin/nix
```

The runner user then can't access the multi-user daemon database, so subsequent `nix develop` fails:

```
error: opening lock file "/nix/var/nix/db/big-lock": Permission denied
```

Net effect on darkmap PR #86: every `flywheel-build` + `flywheel-test` matrix job failed in ~9 seconds.

## Fix

New `.github/actions/setup-nix/action.yml` composite that mirrors Flywheel's `nix-job` detect-or-install pattern:

1. Add `/nix/var/nix/profiles/default/bin` + `$HOME/.nix-profile/bin` to PATH.
2. Probe `command -v nix`.
3. **Preinstalled path**: write a per-user `~/.config/nix/nix.conf` with the requested `experimental-features`. No sudo needed — honored by both single-user and multi-user installs for the runner user.
4. **Not-installed path**: `DeterminateSystems/determinate-nix-action@v3`.

Replaces all 8 use sites of `cachix/install-nix-action@v31` (5 in `spoke-ci.yml`, 3 in `spoke-lane-env.yml`).

## Why a new composite rather than just swapping the cachix action

Two paths need to be handled differently:
- On `ubuntu-latest` (no preinstalled nix) → install via `determinate-nix-action@v3`.
- On `tinyland-nix*` self-hosted (preinstalled multi-user) → don't install, just configure per-user.

A single `uses:` line can't fork on that condition; a composite can.

## Validation

- [x] `ruby -ryaml -e YAML.load_file(...)` clean.
- [x] `actionlint -no-color .github/workflows/spoke-*.yml` clean (modulo pre-existing self-hosted-runner-label false positives).
- [ ] darkmap PR #86 caller re-pinned `@v1.1.1` → `@v1.1.2`: `flywheel-build` + `flywheel-test` produce real work (not 9s permission-denied failures).

## SemVer

v1.1.2 (bugfix). Behavior-compatible — callers that don't notice the install-step swap continue to work.

## Refs

- [TIN-1402](https://linear.app/tinyland/issue/TIN-1402) — this fix
- [TIN-1398](https://linear.app/tinyland/issue/TIN-1398) — darkmap M3-completion canary
- darkmap PR: https://github.com/Jesssullivan/darkmap.tinyland.dev/pull/86