### PR TITLE
fix(flywheel-bazel): v1.1.4 — route bazelisk through nix develop when not on host PATH

### DIFF
--- a/.github/actions/flywheel-bazel/action.yml
+++ b/.github/actions/flywheel-bazel/action.yml
@@ -122,8 +122,23 @@ runs:
         export BAZEL_REMOTE_CACHE="${{ inputs.bazel_remote_cache || env.BAZEL_REMOTE_CACHE }}"
         export BAZEL_REMOTE_EXECUTOR="${{ inputs.bazel_remote_executor || env.BAZEL_REMOTE_EXECUTOR }}"
 
-        echo "::group::bazelisk ${{ inputs.command }} $config_flag ${{ inputs.extra_flags }} ${{ inputs.targets }}"
-        bazelisk ${{ inputs.command }} $config_flag ${{ inputs.extra_flags }} ${{ inputs.targets }}
+        # bazelisk dispatch: prefer host PATH (cluster runner images that
+        # preinstall bazelisk system-wide); fall back to `nix develop
+        # --command` for spokes whose bazelisk is declared in the flake
+        # devShell (Tinyland default). Surfaced by darkmap PR #86 / TIN-1407.
+        if command -v bazelisk >/dev/null 2>&1; then
+          runner=(bazelisk)
+          echo "::notice::Using host bazelisk at $(command -v bazelisk)"
+        elif command -v nix >/dev/null 2>&1 && [ -f flake.nix ]; then
+          runner=(nix develop --command bazelisk)
+          echo "::notice::bazelisk not on host PATH; routing via 'nix develop --command bazelisk'"
+        else
+          echo "::error::bazelisk not on PATH and no flake.nix devShell available to source it from"
+          exit 127
+        fi
+
+        echo "::group::${runner[*]} ${{ inputs.command }} $config_flag ${{ inputs.extra_flags }} ${{ inputs.targets }}"
+        "${runner[@]}" ${{ inputs.command }} $config_flag ${{ inputs.extra_flags }} ${{ inputs.targets }}
         echo "::endgroup::"
 
         echo "executor_used=$executor_used" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/spoke-ci.yml
+++ b/.github/workflows/spoke-ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: nix develop --command just setup
 
       - name: Build (flywheel)
-        uses: tinyland-inc/ci-templates/.github/actions/flywheel-bazel@v1.0.0
+        uses: tinyland-inc/ci-templates/.github/actions/flywheel-bazel@v1.1.4
         with:
           targets: "//:node_modules"
           command: build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed (v1.1.4)
+
+- **`flywheel-bazel` composite — route bazelisk through `nix develop`
+  when not on host PATH** — the action invoked `bazelisk` directly,
+  assuming it lives on the runner's system PATH. On runners that
+  declare bazelisk inside the spoke flake's devShell (the Tinyland
+  default — every spoke flake adds `bazelisk` to `buildInputs`), the
+  bare invocation failed with `bazelisk: command not found` in ~1
+  second. Surfaced by darkmap PR #86 / TIN-1407.
+  Fix: probe `command -v bazelisk`; if found, invoke directly
+  (backward-compatible for runner images that preinstall bazelisk
+  system-wide). If absent and `flake.nix` is present, route the call
+  via `nix develop --command bazelisk ...`. If neither path is
+  available, fail loudly with a clear error.
+  Also bumped the `flywheel-bazel@v1.0.0` pin in `spoke-ci.yml` to
+  `@v1.1.4` so the wrapper workflow picks up the new behavior.
+
 ### Fixed (v1.1.3)
 
 - **`setup-nix` composite — ensure `nixbld` group/users + start the


### PR DESCRIPTION
## Problem

The `flywheel-bazel` composite invoked `bazelisk` as a bare command, assuming it's on the runner's system PATH. On runners that only declare bazelisk inside the spoke flake's devShell (the Tinyland default — every spoke flake adds `bazelisk` to `buildInputs`), the call fails after ~1 second with:

```
bazelisk: command not found
Process completed with exit code 127.
```

Surfaced by darkmap PR #86 / TIN-1407 after v1.1.3 cleared the nix-daemon issue.

## Fix

Probe `command -v bazelisk`:
- If found → invoke directly (backward-compatible for runner images that preinstall bazelisk system-wide).
- If absent and `flake.nix` is present → route via `nix develop --command bazelisk`.
- Else → fail with a clear error.

Also bumped `flywheel-bazel@v1.0.0` → `@v1.1.4` in `spoke-ci.yml` so the wrapper workflow picks up the new behavior.

## SemVer

v1.1.4 (pure bugfix, additive probe). Behavior-compatible for callers that already had bazelisk on host PATH.

## Refs

- TIN-1407 (this release)
- TIN-1398 (darkmap M3-completion canary)
- v1.1.0–v1.1.3 trail: M6 features → parse errors → setup-nix → daemon → bazelisk routing