### PR TITLE
fix(lane-status-check): v1.1.5 — use curl instead of gh api to post statuses

### DIFF
--- a/.github/actions/lane-status-check/action.yml
+++ b/.github/actions/lane-status-check/action.yml
@@ -60,11 +60,24 @@ runs:
 
         echo "$payload" | jq .
 
-        gh api \
-          "/repos/${{ github.repository }}/statuses/${{ inputs.commit_sha }}" \
+        # Use curl rather than `gh api` to avoid taking a dependency on the
+        # gh CLI being on the host PATH. On self-hosted runners where gh
+        # lives inside a flake devShell (the Tinyland default), the prior
+        # `gh api` invocation failed with `gh: command not found` and
+        # surfaced as a fake job failure even after the underlying build
+        # succeeded. Surfaced by darkmap PR #86 / TIN-1414.
+        http_status=$(curl --silent --show-error --output /tmp/lane-status-response.json --write-out '%{http_code}' \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          --input <(echo "$payload")
+          -H "Authorization: Bearer ${GH_TOKEN}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          --data "$payload" \
+          "https://api.github.com/repos/${{ github.repository }}/statuses/${{ inputs.commit_sha }}")
+        if [[ "$http_status" -lt 200 || "$http_status" -ge 300 ]]; then
+          echo "::error::statuses POST returned HTTP $http_status"
+          cat /tmp/lane-status-response.json
+          exit 1
+        fi
 
         echo "context=$context" >> "$GITHUB_OUTPUT"
       env:

--- a/.github/workflows/spoke-ci.yml
+++ b/.github/workflows/spoke-ci.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Post lane build status
         if: always()
-        uses: tinyland-inc/ci-templates/.github/actions/lane-status-check@v1.0.0
+        uses: tinyland-inc/ci-templates/.github/actions/lane-status-check@v1.1.5
         with:
           commit_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           lane_name: ${{ matrix.lane.name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed (v1.1.5)
+
+- **`lane-status-check` composite — use `curl` instead of `gh api`** —
+  the action posted per-lane commit statuses via `gh api`, which
+  requires the GitHub CLI on the host PATH. On runners where `gh`
+  only lives inside the spoke flake's devShell, the call failed with
+  `gh: command not found` (exit 127) and turned successful builds
+  into fake job failures. Surfaced by darkmap PR #86 / TIN-1414 —
+  the `flywheel-build` step's underlying `bazelisk build` succeeded
+  (`state: "success"` payload was even emitted), but the `gh api`
+  POST that followed killed the job.
+  Fix: replaced `gh api` with `curl -X POST` calling the same
+  `/repos/{owner}/{repo}/statuses/{sha}` endpoint directly. `curl`
+  is ubiquitous on Linux runners and doesn't need a flake devShell.
+  Also bumped the `lane-status-check@v1.0.0` pin in `spoke-ci.yml`
+  to `@v1.1.5`.
+
 ### Fixed (v1.1.4)
 
 - **`flywheel-bazel` composite — route bazelisk through `nix develop`


### PR DESCRIPTION
## Problem

The `lane-status-check` composite posted per-lane commit statuses via `gh api`. On Tinyland self-hosted runners where `gh` only lives inside the spoke flake's devShell, the call failed with `gh: command not found` (exit 127) — turning successful builds into fake job failures.

Surfaced by darkmap PR #86 / TIN-1414. The underlying `bazelisk build //:node_modules` step succeeded; the `state: success` payload was even emitted to stdout. But the `gh api` POST that followed killed the job.

## Fix

Replaced `gh api` with `curl -X POST` calling the same `/repos/{owner}/{repo}/statuses/{sha}` endpoint directly. `curl` is ubiquitous on Linux runners; no flake devShell needed.

Also bumped `lane-status-check@v1.0.0` → `@v1.1.5` in `spoke-ci.yml`.

## SemVer

v1.1.5 (pure bugfix). Behavior-compatible.

## Refs

- TIN-1414 (this release)
- TIN-1398 (darkmap M3-completion canary)