### PR TITLE
ci-templates v2 contract: endpoint-free Flywheel and scaffold inheritance

### DIFF
--- a/.github/actions/flywheel-bazel/action.yml
+++ b/.github/actions/flywheel-bazel/action.yml
@@ -1,9 +1,10 @@
 name: flywheel-bazel
 description: |
   Run bazelisk with GloriousFlywheel cache (`--config=flywheel`) or
-  cache+executor (`--config=flywheel-executor`). Wraps the
-  `scripts/bazel-cache-backed.sh` attachment-contract logic so spokes
-  don't carry it. Refuses executor mode on non-cluster runners.
+  cache+executor (`--config=flywheel-executor`). The vendored bazelrc is
+  endpoint-free: this action supplies `--remote_cache` and `--remote_executor`
+  from validated environment or inputs. Refuses executor mode on non-cluster
+  runners.
 
   Contract: tinyland-inc/site.scaffold/docs/CI-SCHEMA.md §5.
 
@@ -32,14 +33,16 @@ inputs:
     default: ""
   bazel_remote_cache:
     description: |
-      Optional override for BAZEL_REMOTE_CACHE env. Default: read from env
-      injected by setup-flywheel / nix-setup composite actions.
+      Optional override for BAZEL_REMOTE_CACHE env. Required when config is
+      flywheel or flywheel-executor. Default: read from env injected by
+      GloriousFlywheel setup actions or operator environment.
     required: false
     default: ""
   bazel_remote_executor:
     description: |
-      Optional override for BAZEL_REMOTE_EXECUTOR env. Default: read from
-      env injected by setup-flywheel / nix-setup.
+      Optional override for BAZEL_REMOTE_EXECUTOR env. Required when config is
+      flywheel-executor. Default: read from env injected by GloriousFlywheel
+      setup actions or operator environment.
     required: false
     default: ""
   runner_class_override:
@@ -112,6 +115,7 @@ runs:
         set -euo pipefail
         config_flag=""
         executor_used=false
+        remote_args=()
         case "${{ inputs.config }}" in
           local)              config_flag="" ;;
           flywheel)           config_flag="--config=flywheel" ;;
@@ -121,6 +125,44 @@ runs:
 
         export BAZEL_REMOTE_CACHE="${{ inputs.bazel_remote_cache || env.BAZEL_REMOTE_CACHE }}"
         export BAZEL_REMOTE_EXECUTOR="${{ inputs.bazel_remote_executor || env.BAZEL_REMOTE_EXECUTOR }}"
+        remote_upload="${GF_BAZEL_REMOTE_UPLOAD:-false}"
+
+        case "$remote_upload" in
+          true|false) ;;
+          *) echo "::error::GF_BAZEL_REMOTE_UPLOAD must be true or false"; exit 64 ;;
+        esac
+
+        if [[ -n "$config_flag" ]]; then
+          if [[ -z "$BAZEL_REMOTE_CACHE" ]]; then
+            echo "::error::BAZEL_REMOTE_CACHE is required for ${{ inputs.config }}. The flywheel bazelrc is endpoint-free by contract."
+            exit 65
+          fi
+          remote_args+=(--remote_cache="$BAZEL_REMOTE_CACHE")
+          remote_args+=(--remote_upload_local_results="$remote_upload")
+          echo "::notice::Bazel remote cache configured from runtime environment (upload=$remote_upload)."
+        fi
+
+        if [[ "${{ inputs.config }}" == "flywheel-executor" ]]; then
+          if [[ -z "$BAZEL_REMOTE_EXECUTOR" ]]; then
+            echo "::error::BAZEL_REMOTE_EXECUTOR is required for flywheel-executor."
+            exit 65
+          fi
+          remote_args+=(--remote_executor="$BAZEL_REMOTE_EXECUTOR")
+          echo "::notice::Bazel remote executor configured from runtime environment."
+        fi
+
+        if [[ -n "${BAZEL_CREDENTIAL_HELPER:-}" ]]; then
+          remote_args+=(--credential_helper="$BAZEL_CREDENTIAL_HELPER")
+        fi
+        if [[ -n "${BAZEL_REMOTE_HEADER:-}" ]]; then
+          remote_args+=(--remote_header="$BAZEL_REMOTE_HEADER")
+        fi
+        if [[ -n "${BAZEL_REMOTE_CACHE_HEADER:-}" ]]; then
+          remote_args+=(--remote_cache_header="$BAZEL_REMOTE_CACHE_HEADER")
+        fi
+        if [[ -n "${BAZEL_REMOTE_EXEC_HEADER:-}" ]]; then
+          remote_args+=(--remote_exec_header="$BAZEL_REMOTE_EXEC_HEADER")
+        fi
 
         # bazelisk dispatch: prefer host PATH (cluster runner images that
         # preinstall bazelisk system-wide); fall back to `nix develop
@@ -137,8 +179,8 @@ runs:
           exit 127
         fi
 
-        echo "::group::${runner[*]} ${{ inputs.command }} $config_flag ${{ inputs.extra_flags }} ${{ inputs.targets }}"
-        "${runner[@]}" ${{ inputs.command }} $config_flag ${{ inputs.extra_flags }} ${{ inputs.targets }}
+        echo "::group::${runner[*]} ${{ inputs.command }} $config_flag <runtime-remote-args> ${{ inputs.extra_flags }} ${{ inputs.targets }}"
+        "${runner[@]}" ${{ inputs.command }} $config_flag "${remote_args[@]}" ${{ inputs.extra_flags }} ${{ inputs.targets }}
         echo "::endgroup::"
 
         echo "executor_used=$executor_used" >> "$GITHUB_OUTPUT"

--- a/.github/actions/flywheel-reapi-proof/action.yml
+++ b/.github/actions/flywheel-reapi-proof/action.yml
@@ -1,0 +1,134 @@
+name: flywheel-reapi-proof
+description: |
+  Dispatch and optionally wait for a GloriousFlywheel executor-backed proof
+  workflow. This is a dispatcher only; the GF workflow remains the proof
+  authority and must publish artifact evidence with remote_processes > 0 and a
+  worker_image_digest before a target class is considered proved.
+
+inputs:
+  gf_repository:
+    description: GloriousFlywheel repository.
+    required: false
+    default: tinyland-inc/GloriousFlywheel
+  gf_workflow:
+    description: GloriousFlywheel proof workflow filename.
+    required: false
+    default: gf-reapi-cell-proof.yml
+  gf_ref:
+    description: GloriousFlywheel ref to run.
+    required: false
+    default: main
+  image_digest:
+    description: Digest-pinned REAPI worker image.
+    required: true
+  target:
+    description: Bazel target to prove.
+    required: true
+  bazel_command:
+    description: Bazel command, usually build or test.
+    required: false
+    default: test
+  consumer_repository:
+    description: Consumer repository being checked out by the proof workflow.
+    required: true
+  consumer_ref:
+    description: Consumer commit/ref to prove.
+    required: true
+  consumer_checkout_authority:
+    description: Checkout authority passed to the GF workflow.
+    required: false
+    default: repo-scoped-deploy-key
+  tinyland_schemas_private_handoff:
+    description: Whether the proof needs Tinyland private schema handoff.
+    required: false
+    default: "false"
+  apply:
+    description: Whether the GF workflow should execute rather than plan.
+    required: false
+    default: "true"
+  force_execution:
+    description: Force remote execution rather than accepting cache hits.
+    required: false
+    default: "true"
+  wait:
+    description: Wait for the GF workflow to finish.
+    required: false
+    default: "true"
+  dispatch_token:
+    description: GitHub token allowed to dispatch and watch the GF workflow.
+    required: true
+
+outputs:
+  run_id:
+    description: Dispatched GF run ID.
+    value: ${{ steps.resolve.outputs.run_id }}
+  run_url:
+    description: Dispatched GF run URL.
+    value: ${{ steps.resolve.outputs.run_url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Dispatch GloriousFlywheel REAPI proof
+      id: dispatch
+      shell: bash
+      run: |
+        set -euo pipefail
+        dispatch_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        gh workflow run "${{ inputs.gf_workflow }}" \
+          --repo "${{ inputs.gf_repository }}" \
+          --ref "${{ inputs.gf_ref }}" \
+          -f image_digest="${{ inputs.image_digest }}" \
+          -f target="${{ inputs.target }}" \
+          -f bazel_command="${{ inputs.bazel_command }}" \
+          -f consumer_repository="${{ inputs.consumer_repository }}" \
+          -f consumer_ref="${{ inputs.consumer_ref }}" \
+          -f consumer_checkout_authority="${{ inputs.consumer_checkout_authority }}" \
+          -f tinyland_schemas_private_handoff="${{ inputs.tinyland_schemas_private_handoff }}" \
+          -f apply="${{ inputs.apply }}" \
+          -f force_execution="${{ inputs.force_execution }}"
+        echo "dispatch_time=${dispatch_time}" >> "${GITHUB_OUTPUT}"
+      env:
+        GH_TOKEN: ${{ inputs.dispatch_token }}
+
+    - name: Resolve dispatched run
+      id: resolve
+      shell: bash
+      run: |
+        set -euo pipefail
+        run_id=""
+        for _ in $(seq 1 60); do
+          run_id="$(
+            gh run list \
+              --repo "${{ inputs.gf_repository }}" \
+              --workflow "${{ inputs.gf_workflow }}" \
+              --event workflow_dispatch \
+              --branch "${{ inputs.gf_ref }}" \
+              --limit 20 \
+              --json databaseId,createdAt \
+              --jq "[.[] | select(.createdAt >= \"${{ steps.dispatch.outputs.dispatch_time }}\")] | sort_by(.createdAt, .databaseId) | last | .databaseId // \"\""
+          )"
+          if [ -n "${run_id}" ]; then
+            break
+          fi
+          sleep 5
+        done
+        if [ -z "${run_id}" ]; then
+          echo "::error::Could not resolve dispatched GloriousFlywheel proof run"
+          exit 1
+        fi
+        run_url="$(gh run view "${run_id}" --repo "${{ inputs.gf_repository }}" --json url --jq .url)"
+        {
+          echo "run_id=${run_id}"
+          echo "run_url=${run_url}"
+        } >> "${GITHUB_OUTPUT}"
+        echo "::notice::GloriousFlywheel proof run: ${run_url}"
+      env:
+        GH_TOKEN: ${{ inputs.dispatch_token }}
+
+    - name: Wait for GloriousFlywheel REAPI proof
+      if: inputs.wait == 'true'
+      shell: bash
+      run: gh run watch "${{ steps.resolve.outputs.run_id }}" --repo "${{ inputs.gf_repository }}" --exit-status
+      env:
+        GH_TOKEN: ${{ inputs.dispatch_token }}

--- a/.github/actions/greedy-cache/action.yml
+++ b/.github/actions/greedy-cache/action.yml
@@ -29,7 +29,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: tinyland-inc/ci-templates/.github/actions/nix-setup@main
+    - uses: tinyland-inc/ci-templates/.github/actions/nix-setup@v2
       with:
         attic-server: ${{ inputs.attic-server }}
         attic-cache: ${{ inputs.attic-cache }}

--- a/.github/actions/inherit-scaffold-skills/action.yml
+++ b/.github/actions/inherit-scaffold-skills/action.yml
@@ -1,0 +1,236 @@
+name: inherit-scaffold-skills
+description: |
+  Pull the scaffold-core agent/AX plugin from tinyland-inc/site.scaffold at a
+  pinned ref, then materialize canonical `.agents/skills` and `.claude/skills`
+  surfaces for a spoke repo.
+
+inputs:
+  scaffold_repository:
+    description: Repository that owns the scaffold-core plugin.
+    required: false
+    default: tinyland-inc/site.scaffold
+  scaffold_ref:
+    description: |
+      Pinned scaffold ref to inherit from. Must be a semver tag, refs/tags/*
+      ref, or full 40-character commit SHA unless allow_unpinned_ref=true.
+    required: true
+  github_token:
+    description: Token used by actions/checkout for private scaffold refs.
+    required: false
+    default: ""
+  source_path:
+    description: Path to the plugin inside the scaffold checkout.
+    required: false
+    default: plugins/scaffold-core
+  target_path:
+    description: Path to write the inherited plugin in the consumer checkout.
+    required: false
+    default: plugins/scaffold-core
+  mode:
+    description: sync writes files; check only reports drift and fails if stale.
+    required: false
+    default: sync
+  install_agent_skills:
+    description: Copy plugin skills into `.agents/skills`.
+    required: false
+    default: "true"
+  agent_skills_path:
+    description: Consumer path for canonical Codex/OpenAI skill bodies.
+    required: false
+    default: .agents/skills
+  install_claude_symlinks:
+    description: Create `.claude/skills/<name>` symlinks to `.agents/skills/<name>`.
+    required: false
+    default: "true"
+  claude_skills_path:
+    description: Consumer path for Claude Code skill discovery links.
+    required: false
+    default: .claude/skills
+  allow_unpinned_ref:
+    description: |
+      Escape hatch for local testing only. Production spoke workflows should
+      keep this false so `main`/branch refs cannot silently drift.
+    required: false
+    default: "false"
+
+outputs:
+  plugin_path:
+    description: Consumer path containing the inherited scaffold-core plugin.
+    value: ${{ steps.inherit.outputs.plugin_path }}
+  skill_count:
+    description: Number of inherited skill directories.
+    value: ${{ steps.inherit.outputs.skill_count }}
+  scaffold_ref:
+    description: Scaffold ref used for inheritance.
+    value: ${{ steps.inherit.outputs.scaffold_ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate pinned scaffold ref
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        ref="${{ inputs.scaffold_ref }}"
+        allow_unpinned="${{ inputs.allow_unpinned_ref }}"
+        if [[ -z "$ref" ]]; then
+          echo "::error::scaffold_ref is required"
+          exit 1
+        fi
+
+        case "$ref" in
+          main|master|develop|trunk|HEAD|refs/heads/*)
+            if [[ "$allow_unpinned" != "true" ]]; then
+              echo "::error::scaffold_ref=$ref is not pinned. Use a semver tag, refs/tags/*, or a full commit SHA."
+              exit 1
+            fi
+            ;;
+          refs/tags/*)
+            ;;
+          *)
+            if [[ "$ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9._-]+)?$ ]]; then
+              :
+            elif [[ "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+              :
+            elif [[ "$allow_unpinned" == "true" ]]; then
+              echo "::warning::allow_unpinned_ref=true permits scaffold_ref=$ref"
+            else
+              echo "::error::scaffold_ref=$ref is not an accepted pinned ref. Use vX.Y.Z, refs/tags/*, or a full commit SHA."
+              exit 1
+            fi
+            ;;
+        esac
+
+    - name: Checkout scaffold source
+      uses: actions/checkout@v6
+      with:
+        repository: ${{ inputs.scaffold_repository }}
+        ref: ${{ inputs.scaffold_ref }}
+        path: .ci-templates-scaffold-source
+        persist-credentials: false
+        token: ${{ inputs.github_token || github.token }}
+
+    - name: Inherit scaffold skills
+      id: inherit
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        source_path=".ci-templates-scaffold-source/${{ inputs.source_path }}"
+        target_path="${{ inputs.target_path }}"
+        mode="${{ inputs.mode }}"
+        install_agent_skills="${{ inputs.install_agent_skills }}"
+        install_claude_symlinks="${{ inputs.install_claude_symlinks }}"
+        agent_skills_path="${{ inputs.agent_skills_path }}"
+        claude_skills_path="${{ inputs.claude_skills_path }}"
+
+        case "$mode" in
+          sync|check) ;;
+          *)
+            echo "::error::mode must be sync or check; got $mode"
+            exit 1
+            ;;
+        esac
+
+        if [[ ! -d "$source_path" ]]; then
+          echo "::error::scaffold plugin not found at ${{ inputs.scaffold_repository }}@${{ inputs.scaffold_ref }}:${{ inputs.source_path }}"
+          exit 1
+        fi
+        if [[ ! -f "$source_path/plugin.json" ]]; then
+          echo "::error::scaffold plugin missing plugin.json at $source_path"
+          exit 1
+        fi
+        if [[ ! -d "$source_path/skills" ]]; then
+          echo "::error::scaffold plugin missing skills/ at $source_path"
+          exit 1
+        fi
+
+        python3 - <<PY
+        import json
+        from pathlib import Path
+        plugin = json.loads(Path("$source_path/plugin.json").read_text())
+        if not isinstance(plugin, dict):
+            raise SystemExit("::error::plugin.json must contain an object")
+        for key in ("name", "version"):
+            if not plugin.get(key):
+                raise SystemExit(f"::error::plugin.json missing required key: {key}")
+        PY
+
+        skill_count="$(
+          find -L "$source_path/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' '
+        )"
+        if [[ "$skill_count" -lt 1 ]]; then
+          echo "::error::scaffold plugin contains no skills"
+          exit 1
+        fi
+
+        tmp_path="${target_path}.tmp-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}"
+        rm -rf "$tmp_path"
+        mkdir -p "$(dirname "$tmp_path")"
+        cp -R -L "$source_path" "$tmp_path"
+
+        if [[ "$mode" == "check" ]]; then
+          if [[ ! -d "$target_path" ]]; then
+            echo "::error::$target_path is missing; run inherit-scaffold-skills in sync mode"
+            exit 1
+          fi
+          if ! diff -ruN "$tmp_path" "$target_path"; then
+            echo "::error::$target_path differs from ${{ inputs.scaffold_repository }}@${{ inputs.scaffold_ref }}:${{ inputs.source_path }}"
+            exit 1
+          fi
+          rm -rf "$tmp_path"
+        else
+          mkdir -p "$(dirname "$target_path")"
+          rm -rf "$target_path"
+          mv "$tmp_path" "$target_path"
+        fi
+
+        if [[ "$mode" == "sync" && "$install_agent_skills" == "true" ]]; then
+          mkdir -p "$agent_skills_path"
+          while IFS= read -r -d '' skill_dir; do
+            skill_name="$(basename "$skill_dir")"
+            rm -rf "$agent_skills_path/$skill_name"
+            cp -R -L "$skill_dir" "$agent_skills_path/$skill_name"
+          done < <(find "$target_path/skills" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+        elif [[ "$install_agent_skills" != "true" && "$install_agent_skills" != "false" ]]; then
+          echo "::error::install_agent_skills must be true or false"
+          exit 1
+        fi
+
+        if [[ "$mode" == "sync" && "$install_claude_symlinks" == "true" ]]; then
+          if [[ "$install_agent_skills" != "true" ]]; then
+            echo "::error::install_claude_symlinks=true requires install_agent_skills=true"
+            exit 1
+          fi
+          mkdir -p "$claude_skills_path"
+          while IFS= read -r -d '' skill_dir; do
+            skill_name="$(basename "$skill_dir")"
+            link_path="$claude_skills_path/$skill_name"
+            link_target="$(
+              python3 - <<PY
+        import os
+        print(os.path.relpath("$agent_skills_path/$skill_name", "$claude_skills_path"))
+        PY
+            )"
+            rm -rf "$link_path"
+            ln -s "$link_target" "$link_path"
+          done < <(find "$agent_skills_path" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+        elif [[ "$install_claude_symlinks" != "true" && "$install_claude_symlinks" != "false" ]]; then
+          echo "::error::install_claude_symlinks must be true or false"
+          exit 1
+        fi
+
+        {
+          echo "plugin_path=$target_path"
+          echo "skill_count=$skill_count"
+          echo "scaffold_ref=${{ inputs.scaffold_ref }}"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "::notice::inherited $skill_count scaffold skill(s) from ${{ inputs.scaffold_repository }}@${{ inputs.scaffold_ref }}"
+
+    - name: Remove scaffold checkout
+      shell: bash
+      if: always()
+      run: |
+        rm -rf .ci-templates-scaffold-source

--- a/.github/actions/lane-ttl-reap/action.yml
+++ b/.github/actions/lane-ttl-reap/action.yml
@@ -1,0 +1,125 @@
+name: lane-ttl-reap
+description: |
+  Construct + emit the Blahaj `<spoke>-lane-ttl-reap`
+  `repository_dispatch` payload for scheduled expired-lane cleanup.
+  Blahaj owns listing and idempotent destruction.
+
+inputs:
+  spoke:
+    description: Spoke slug.
+    required: true
+  domain:
+    description: Spoke brand domain.
+    required: true
+  dry_run:
+    description: Ask Blahaj to report expired lanes without deleting them.
+    required: false
+    default: "false"
+  blahaj_repository:
+    description: Target repository for the repository_dispatch.
+    required: false
+    default: tinyland-inc/blahaj
+  dispatch_token:
+    description: GitHub token with repo:dispatch scope on blahaj_repository. Required unless local dry_run_only is true.
+    required: false
+    default: ""
+  dry_run_only:
+    description: Build + validate the payload but do not POST.
+    required: false
+    default: "false"
+
+outputs:
+  payload_path:
+    description: Saved payload path.
+    value: ${{ steps.build.outputs.payload_path }}
+  dispatch_id:
+    description: Synthetic dispatch ID.
+    value: ${{ steps.build.outputs.dispatch_id }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build TTL reap payload
+      id: build
+      shell: bash
+      run: |
+        set -euo pipefail
+        requested_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        case "${{ inputs.dry_run }}" in true|false) ;; *) echo "::error::dry_run must be true or false"; exit 64 ;; esac
+
+        payload="$(jq -nc \
+          --arg event_type "${{ inputs.spoke }}-lane-ttl-reap" \
+          --arg spoke "${{ inputs.spoke }}" \
+          --arg domain "${{ inputs.domain }}" \
+          --arg requested_at "${requested_at}" \
+          --argjson dry_run "${{ inputs.dry_run }}" \
+          '{
+            event_type: $event_type,
+            client_payload: {
+              schema_version: 1,
+              operation: "reap-expired",
+              spoke: $spoke,
+              domain: $domain,
+              requested_at: $requested_at,
+              dry_run: $dry_run
+            }
+          }')"
+
+        dispatch_id="${{ inputs.spoke }}-ttl-reap-${GITHUB_RUN_ID}"
+        payload_path="${RUNNER_TEMP}/lane-ttl-reap-${dispatch_id}.json"
+        echo "${payload}" | jq . > "${payload_path}"
+        {
+          echo "dispatch_id=${dispatch_id}"
+          echo "payload_path=${payload_path}"
+        } >> "${GITHUB_OUTPUT}"
+        cat "${payload_path}"
+
+    - name: Validate against schema
+      shell: bash
+      run: |
+        set -euo pipefail
+        schema="${{ github.action_path }}/../../../schemas/lane-ttl-reap-dispatch.schema.json"
+        python3 - <<PY
+        import json, re, sys
+        try:
+            from jsonschema import Draft202012Validator
+        except ImportError:
+            Draft202012Validator = None
+        schema = json.load(open("$schema"))
+        payload = json.load(open("${{ steps.build.outputs.payload_path }}"))
+        if Draft202012Validator is None:
+            cp = payload.get("client_payload", {})
+            ok = (
+                re.match(r"^[a-z][a-z0-9-]+-lane-ttl-reap$", payload.get("event_type", "")) and
+                cp.get("schema_version") == 1 and
+                cp.get("operation") == "reap-expired" and
+                isinstance(cp.get("dry_run"), bool)
+            )
+            if not ok:
+                print("::error::payload failed minimal lane-ttl-reap validation", file=sys.stderr)
+                sys.exit(1)
+            print("::warning::jsonschema unavailable; used minimal lane-ttl-reap validation")
+        else:
+            errs = sorted(Draft202012Validator(schema).iter_errors(payload), key=lambda e: list(e.absolute_path))
+            if errs:
+                for e in errs:
+                    p = "/" + "/".join(str(x) for x in e.absolute_path)
+                    print(f"::error::payload at {p}: {e.message}", file=sys.stderr)
+                sys.exit(1)
+        PY
+
+    - name: Dispatch
+      if: inputs.dry_run_only != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -z "${{ inputs.dispatch_token }}" ]]; then
+          echo "::error::dispatch_token is required when dry_run_only=false"
+          exit 1
+        fi
+        gh api "/repos/${{ inputs.blahaj_repository }}/dispatches" \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          --input "${{ steps.build.outputs.payload_path }}"
+      env:
+        GH_TOKEN: ${{ inputs.dispatch_token }}

--- a/.github/actions/lanes-load/action.yml
+++ b/.github/actions/lanes-load/action.yml
@@ -57,7 +57,18 @@ runs:
           echo "::error::lanes.json not found at ${{ inputs.path }}"
           exit 1
         fi
-        python3 - <<PY
+
+        if python3 -c 'import jsonschema' >/dev/null 2>&1; then
+          validator=(python3)
+        elif command -v nix >/dev/null 2>&1 && [[ -f flake.nix ]]; then
+          validator=(nix develop --command python3)
+          echo "::notice::host python lacks jsonschema; validating via nix develop"
+        else
+          echo "::error::python jsonschema is unavailable and no flake.nix dev shell exists"
+          exit 2
+        fi
+
+        "${validator[@]}" - <<PY
         import json, sys
         from jsonschema import Draft202012Validator
         schema = json.load(open("$schema"))

--- a/.github/actions/nix-build/action.yml
+++ b/.github/actions/nix-build/action.yml
@@ -27,7 +27,7 @@ runs:
         extra_nix_config: |
           accept-flake-config = true
 
-    - uses: tinyland-inc/ci-templates/.github/actions/nix-setup@main
+    - uses: tinyland-inc/ci-templates/.github/actions/nix-setup@v2
       with:
         attic-server: ${{ inputs.attic-server }}
         attic-cache: ${{ inputs.attic-cache }}

--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -1,5 +1,5 @@
 name: "Nix Setup"
-description: "Configure Nix and cache endpoints. Auto-detects Attic and Bazel on self-hosted ARC runners. Outputs cluster-reachability flags consumed by `flywheel-bazel`."
+description: "Configure Nix and cache hints. Attic may be auto-detected on self-hosted ARC runners; Bazel endpoints are runtime authority supplied by environment or inputs. Outputs cluster-reachability flags consumed by `flywheel-bazel`."
 
 inputs:
   attic-server:
@@ -9,7 +9,7 @@ inputs:
     description: "Attic cache name"
     default: "main"
   bazel-cache:
-    description: "Bazel remote cache endpoint (auto-detected on self-hosted)"
+    description: "Bazel remote cache endpoint. Optional override for BAZEL_REMOTE_CACHE; no endpoint is invented by this action."
     default: ""
 
 outputs:
@@ -62,14 +62,21 @@ runs:
             echo "::warning::Attic cache DNS unreachable ($ATTIC_HOST) — running without cache"
           fi
 
-          BAZEL="${{ inputs.bazel-cache }}"
-          BAZEL_URL="${BAZEL:-${BAZEL_REMOTE_CACHE:-grpc://bazel-cache.nix-cache.svc.cluster.local:9092}}"
-          BAZEL_HOST=$(echo "$BAZEL_URL" | sed 's|grpcs\?://||;s|:.*||')
-          if getent hosts "$BAZEL_HOST" >/dev/null 2>&1; then
-            echo "BAZEL_REMOTE_CACHE=$BAZEL_URL" >> "$GITHUB_ENV"
-            bazel_cache_reachable=true
+          BAZEL_URL="${{ inputs.bazel-cache }}"
+          if [ -z "$BAZEL_URL" ]; then
+            BAZEL_URL="${BAZEL_REMOTE_CACHE:-}"
+          fi
+
+          if [ -n "$BAZEL_URL" ]; then
+            BAZEL_HOST=$(echo "$BAZEL_URL" | sed 's|grpcs\?://||;s|:.*||')
+            if getent hosts "$BAZEL_HOST" >/dev/null 2>&1; then
+              echo "BAZEL_REMOTE_CACHE=$BAZEL_URL" >> "$GITHUB_ENV"
+              bazel_cache_reachable=true
+            else
+              echo "::warning::Configured Bazel cache DNS unreachable ($BAZEL_HOST) — Flywheel Bazel commands will fail fast unless another step supplies BAZEL_REMOTE_CACHE"
+            fi
           else
-            echo "::warning::Bazel cache DNS unreachable ($BAZEL_HOST) — running without remote cache"
+            echo "::notice::No BAZEL_REMOTE_CACHE configured by input or environment; Flywheel Bazel commands will fail fast if selected."
           fi
         elif [ -n "${{ inputs.attic-server }}" ]; then
           echo "ATTIC_SERVER=${{ inputs.attic-server }}" >> "$GITHUB_ENV"

--- a/.github/actions/public-preview-dispatch/action.yml
+++ b/.github/actions/public-preview-dispatch/action.yml
@@ -1,0 +1,217 @@
+name: public-preview-dispatch
+description: |
+  Construct + emit the Blahaj `<spoke>-public-preview`
+  `repository_dispatch` payload for explicit public/client review aliases.
+  Blahaj owns Cloudflare DNS, Access, Tunnel ingress, and cleanup.
+
+inputs:
+  operation:
+    description: provision or destroy.
+    required: false
+    default: provision
+  spoke:
+    description: Spoke slug.
+    required: true
+  source_repository:
+    description: Source repository in owner/name form.
+    required: true
+  source_pr:
+    description: Source pull request number.
+    required: true
+  source_commit:
+    description: Full 40-character source commit SHA.
+    required: true
+  lane:
+    description: Lane or env identity being publicly exposed.
+    required: true
+  origin_fqdn:
+    description: Existing tailnet or internal hostname that Cloudflare should route to.
+    required: true
+  origin_service:
+    description: Optional explicit Cloudflare Tunnel service URL. Blahaj may resolve from route authority when omitted.
+    required: false
+    default: ""
+  origin_host_header:
+    description: Optional Host header for the Cloudflare Tunnel origin request. Defaults to origin_fqdn.
+    required: false
+    default: ""
+  preview_hostname:
+    description: Public hostname to create.
+    required: true
+  ttl_hours:
+    description: Public preview TTL in hours. Max 168.
+    required: false
+    default: "72"
+  description:
+    description: Human-readable preview purpose.
+    required: false
+    default: ""
+  allow_emails_json:
+    description: JSON array of email addresses allowed through Cloudflare Access.
+    required: false
+    default: "[]"
+  allow_email_domains_json:
+    description: JSON array of email domains allowed through Cloudflare Access.
+    required: false
+    default: "[]"
+  session_duration:
+    description: Cloudflare Access session duration.
+    required: false
+    default: "24h"
+  blahaj_repository:
+    description: Target repository for the repository_dispatch.
+    required: false
+    default: tinyland-inc/blahaj
+  dispatch_token:
+    description: GitHub token with repo:dispatch scope on blahaj_repository. Required unless dry_run.
+    required: false
+    default: ""
+  dry_run:
+    description: If true, build + validate the payload but do not POST.
+    required: false
+    default: "false"
+
+outputs:
+  dispatch_id:
+    description: Synthetic dispatch ID.
+    value: ${{ steps.build.outputs.dispatch_id }}
+  payload_path:
+    description: Saved payload path.
+    value: ${{ steps.build.outputs.payload_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Build payload
+      id: build
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        case "${{ inputs.operation }}" in
+          provision|destroy) ;;
+          *) echo "::error::operation must be provision or destroy"; exit 64 ;;
+        esac
+
+        if ! [[ "${{ inputs.ttl_hours }}" =~ ^[0-9]+$ ]] || [ "${{ inputs.ttl_hours }}" -lt 1 ] || [ "${{ inputs.ttl_hours }}" -gt 168 ]; then
+          echo "::error::ttl_hours must be an integer from 1 through 168"
+          exit 64
+        fi
+
+        emails='${{ inputs.allow_emails_json }}'
+        domains='${{ inputs.allow_email_domains_json }}'
+        jq -e 'type == "array" and all(.[]; type == "string")' <<<"${emails}" >/dev/null
+        jq -e 'type == "array" and all(.[]; type == "string")' <<<"${domains}" >/dev/null
+
+        payload="$(jq -nc \
+          --arg event_type "${{ inputs.spoke }}-public-preview" \
+          --arg operation "${{ inputs.operation }}" \
+          --arg spoke "${{ inputs.spoke }}" \
+          --arg source_repository "${{ inputs.source_repository }}" \
+          --argjson source_pr "${{ inputs.source_pr }}" \
+          --arg source_commit "${{ inputs.source_commit }}" \
+          --arg lane "${{ inputs.lane }}" \
+          --arg origin_fqdn "${{ inputs.origin_fqdn }}" \
+          --arg origin_service "${{ inputs.origin_service }}" \
+          --arg origin_host_header "${{ inputs.origin_host_header }}" \
+          --arg preview_hostname "${{ inputs.preview_hostname }}" \
+          --argjson ttl_hours "${{ inputs.ttl_hours }}" \
+          --arg description "${{ inputs.description }}" \
+          --argjson allow_emails "${emails}" \
+          --argjson allow_email_domains "${domains}" \
+          --arg session_duration "${{ inputs.session_duration }}" \
+          '{
+            event_type: $event_type,
+            client_payload: ({
+              schema_version: 1,
+              operation: $operation,
+              spoke: $spoke,
+              source_repository: $source_repository,
+              source_pr: $source_pr,
+              source_commit: $source_commit,
+              lane: $lane,
+              origin_fqdn: $origin_fqdn,
+              preview_hostname: $preview_hostname,
+              ttl_hours: $ttl_hours,
+              auth: {
+                provider: "cloudflare-access",
+                identity_provider: "One-time PIN",
+                allow_emails: $allow_emails,
+                allow_email_domains: $allow_email_domains,
+                session_duration: $session_duration
+              }
+            }
+            + (if $origin_service == "" then {} else {origin_service: $origin_service} end)
+            + (if $origin_host_header == "" then {} else {origin_host_header: $origin_host_header} end)
+            + (if $description == "" then {} else {description: $description} end))
+          }')"
+
+        dispatch_id="${{ inputs.spoke }}-public-preview-pr${{ inputs.source_pr }}-${GITHUB_RUN_ID}"
+        payload_path="${RUNNER_TEMP}/public-preview-${dispatch_id}.json"
+        echo "${payload}" | jq . > "${payload_path}"
+        {
+          echo "dispatch_id=${dispatch_id}"
+          echo "payload_path=${payload_path}"
+        } >> "${GITHUB_OUTPUT}"
+
+        echo "::group::Public preview dispatch payload (${dispatch_id})"
+        cat "${payload_path}"
+        echo "::endgroup::"
+
+    - name: Validate against schema
+      shell: bash
+      run: |
+        set -euo pipefail
+        schema="${{ github.action_path }}/../../../schemas/public-preview-dispatch.schema.json"
+        python3 - <<PY
+        import json, re, sys
+        try:
+            from jsonschema import Draft202012Validator
+        except ImportError:
+            Draft202012Validator = None
+        schema = json.load(open("$schema"))
+        payload = json.load(open("${{ steps.build.outputs.payload_path }}"))
+        if Draft202012Validator is None:
+            cp = payload.get("client_payload", {})
+            ok = (
+                re.match(r"^[a-z][a-z0-9-]+-public-preview$", payload.get("event_type", "")) and
+                cp.get("schema_version") == 1 and
+                cp.get("operation") in {"provision", "destroy"} and
+                cp.get("auth", {}).get("provider") == "cloudflare-access" and
+                cp.get("auth", {}).get("identity_provider") == "One-time PIN" and
+                (cp.get("auth", {}).get("allow_emails") or cp.get("auth", {}).get("allow_email_domains"))
+            )
+            if not ok:
+                print("::error::payload failed minimal public-preview validation", file=sys.stderr)
+                sys.exit(1)
+            print("::warning::jsonschema unavailable; used minimal public-preview validation")
+        else:
+            errs = sorted(Draft202012Validator(schema).iter_errors(payload), key=lambda e: list(e.absolute_path))
+            if errs:
+                for e in errs:
+                    p = "/" + "/".join(str(x) for x in e.absolute_path)
+                    print(f"::error::payload at {p}: {e.message}", file=sys.stderr)
+                sys.exit(1)
+        PY
+
+    - name: Dispatch
+      if: inputs.dry_run != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -z "${{ inputs.dispatch_token }}" ]]; then
+          echo "::error::dispatch_token is required when dry_run=false"
+          exit 1
+        fi
+        gh api "/repos/${{ inputs.blahaj_repository }}/dispatches" \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          --input "${{ steps.build.outputs.payload_path }}"
+        echo "::notice::dispatched ${{ steps.build.outputs.dispatch_id }} -> ${{ inputs.blahaj_repository }}"
+      env:
+        GH_TOKEN: ${{ inputs.dispatch_token }}
+
+    - name: Dry-run notice
+      if: inputs.dry_run == 'true'
+      shell: bash
+      run: echo "::notice::dry_run=true - public preview payload built and validated, NOT dispatched"

--- a/.github/actions/repo-manifest-validate/action.yml
+++ b/.github/actions/repo-manifest-validate/action.yml
@@ -1,0 +1,97 @@
+name: repo-manifest-validate
+description: |
+  Validate tinyland.repo.json against the Tinyland repo manifest schema and,
+  optionally, require one or more taxonomy roles.
+
+inputs:
+  path:
+    description: Path to tinyland.repo.json relative to the consumer repo checkout.
+    required: false
+    default: tinyland.repo.json
+  required_roles:
+    description: |
+      Optional comma-separated list of accepted taxonomy.primary_role values.
+      Example: static-spoke,static-spoke-scaffold
+    required: false
+    default: ""
+
+outputs:
+  primary_role:
+    description: taxonomy.primary_role from the manifest.
+    value: ${{ steps.read.outputs.primary_role }}
+  repo_name:
+    description: repo.name from the manifest.
+    value: ${{ steps.read.outputs.repo_name }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate repo manifest schema
+      shell: bash
+      run: |
+        set -euo pipefail
+        schema="${{ github.action_path }}/../../../schemas/tinyland-repo-manifest.schema.json"
+        manifest="${{ inputs.path }}"
+        if [[ ! -f "$schema" ]]; then
+          echo "::error::ci-templates schema missing at $schema"
+          exit 1
+        fi
+        if [[ ! -f "$manifest" ]]; then
+          echo "::error::repo manifest not found at $manifest"
+          exit 1
+        fi
+
+        if python3 -c 'import jsonschema' >/dev/null 2>&1; then
+          validator=(python3)
+        elif command -v nix >/dev/null 2>&1 && [[ -f flake.nix ]]; then
+          validator=(nix develop --command python3)
+          echo "::notice::host python lacks jsonschema; validating via nix develop"
+        else
+          echo "::error::python jsonschema is unavailable and no flake.nix dev shell exists"
+          exit 2
+        fi
+
+        "${validator[@]}" - <<PY
+        import json, sys
+        from jsonschema import Draft202012Validator
+        schema = json.load(open("$schema"))
+        inst = json.load(open("$manifest"))
+        Draft202012Validator.check_schema(schema)
+        errors = sorted(Draft202012Validator(schema).iter_errors(inst), key=lambda e: list(e.absolute_path))
+        if errors:
+            for e in errors:
+                p = "/" + "/".join(str(x) for x in e.absolute_path)
+                print(f"::error file=$manifest::at {p}: {e.message}", file=sys.stderr)
+            sys.exit(1)
+        PY
+
+    - name: Read manifest role
+      id: read
+      shell: bash
+      run: |
+        set -euo pipefail
+        manifest="${{ inputs.path }}"
+        primary_role=$(jq -r '.taxonomy.primary_role' "$manifest")
+        repo_name=$(jq -r '.repo.name' "$manifest")
+        required="${{ inputs.required_roles }}"
+
+        if [[ -n "$required" ]]; then
+          found=false
+          IFS=',' read -ra roles <<< "$required"
+          for role in "${roles[@]}"; do
+            if [[ "$primary_role" == "$role" ]]; then
+              found=true
+              break
+            fi
+          done
+          if [[ "$found" != "true" ]]; then
+            echo "::error file=$manifest::taxonomy.primary_role=$primary_role is not one of: $required"
+            exit 1
+          fi
+        fi
+
+        {
+          echo "primary_role=$primary_role"
+          echo "repo_name=$repo_name"
+        } >> "$GITHUB_OUTPUT"
+        echo "::notice::repo manifest valid (repo=$repo_name, primary_role=$primary_role)"

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -282,7 +282,7 @@ jobs:
 
       - name: Configure self-hosted cache contract
         if: ${{ runner.environment != 'github-hosted' }}
-        uses: tinyland-inc/ci-templates/.github/actions/nix-setup@main
+        uses: tinyland-inc/ci-templates/.github/actions/nix-setup@v2
 
       - name: Resolve working directory
         shell: bash
@@ -670,7 +670,7 @@ jobs:
 
       - name: Configure self-hosted cache contract
         if: ${{ runner.environment != 'github-hosted' }}
-        uses: tinyland-inc/ci-templates/.github/actions/nix-setup@main
+        uses: tinyland-inc/ci-templates/.github/actions/nix-setup@v2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -750,7 +750,7 @@ jobs:
 
       - name: Configure self-hosted cache contract
         if: ${{ runner.environment != 'github-hosted' }}
-        uses: tinyland-inc/ci-templates/.github/actions/nix-setup@main
+        uses: tinyland-inc/ci-templates/.github/actions/nix-setup@v2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:

--- a/.github/workflows/spoke-ci.yml
+++ b/.github/workflows/spoke-ci.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
-      - uses: tinyland-inc/ci-templates/.github/actions/secrets-scan@v1.0.0
+      - uses: tinyland-inc/ci-templates/.github/actions/secrets-scan@v2
 
   lanes-load:
     runs-on: ubuntu-latest
@@ -72,14 +72,34 @@ jobs:
       spoke_name: ${{ steps.load.outputs.spoke_name }}
     steps:
       - uses: actions/checkout@v6
-      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.3
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v2
       - id: load
-        uses: tinyland-inc/ci-templates/.github/actions/lanes-load@v1.0.0
+        uses: tinyland-inc/ci-templates/.github/actions/lanes-load@v2
         with:
           path: ${{ inputs.lanes_path }}
 
+  repo-manifest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v2
+      - id: manifest
+        shell: bash
+        run: |
+          if [[ -f tinyland.repo.json ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::tinyland.repo.json not present; skipping manifest validation for this pre-manifest consumer."
+          fi
+      - if: steps.manifest.outputs.exists == 'true'
+        uses: tinyland-inc/ci-templates/.github/actions/repo-manifest-validate@v2
+        with:
+          required_roles: static-spoke,static-spoke-scaffold
+
   flywheel-build:
-    needs: [secrets-scan, lanes-load]
+    needs: [secrets-scan, repo-manifest, lanes-load]
     strategy:
       fail-fast: false
       matrix:
@@ -88,13 +108,13 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.3
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v2
 
       - name: Setup workspace
         run: nix develop --command just setup
 
       - name: Build (flywheel)
-        uses: tinyland-inc/ci-templates/.github/actions/flywheel-bazel@v1.1.4
+        uses: tinyland-inc/ci-templates/.github/actions/flywheel-bazel@v2
         with:
           targets: "//:node_modules"
           command: build
@@ -106,7 +126,7 @@ jobs:
 
       - name: Post lane build status
         if: always()
-        uses: tinyland-inc/ci-templates/.github/actions/lane-status-check@v1.1.5
+        uses: tinyland-inc/ci-templates/.github/actions/lane-status-check@v2
         with:
           commit_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           lane_name: ${{ matrix.lane.name }}
@@ -114,7 +134,7 @@ jobs:
           description: "build-and-test (${{ matrix.lane.name }})"
 
   flywheel-test:
-    needs: [secrets-scan, lanes-load]
+    needs: [secrets-scan, repo-manifest, lanes-load]
     strategy:
       fail-fast: false
       matrix:
@@ -123,7 +143,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.3
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v2
 
       - run: nix develop --command just setup
       - run: nix develop --command just check
@@ -134,7 +154,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.3
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v2
       - run: nix develop --command bazelisk mod graph
       - run: nix develop --command bazelisk build //:node_modules
 
@@ -149,6 +169,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.3
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v2
       - run: nix develop --command just setup
       - run: nix develop --command just test-e2e

--- a/.github/workflows/spoke-lane-env.yml
+++ b/.github/workflows/spoke-lane-env.yml
@@ -82,9 +82,9 @@ jobs:
       spoke_domain: ${{ steps.load.outputs.spoke_domain }}
     steps:
       - uses: actions/checkout@v6
-      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.3
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v2
       - id: load
-        uses: tinyland-inc/ci-templates/.github/actions/lanes-load@v1.0.0
+        uses: tinyland-inc/ci-templates/.github/actions/lanes-load@v2
         with:
           path: ${{ inputs.lanes_path }}
 
@@ -131,8 +131,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.3
-      - uses: tinyland-inc/ci-templates/.github/actions/lane-dispatch@v1.0.0
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v2
+      - uses: tinyland-inc/ci-templates/.github/actions/lane-dispatch@v2
         with:
           pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
           commit_sha: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -168,8 +168,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v1.1.3
-      - uses: tinyland-inc/ci-templates/.github/actions/lane-reap@v1.0.0
+      - uses: tinyland-inc/ci-templates/.github/actions/setup-nix@v2
+      - uses: tinyland-inc/ci-templates/.github/actions/lane-reap@v2
         with:
           pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
           spoke: ${{ needs.lanes-load.outputs.spoke_name }}

--- a/.github/workflows/spoke-lane-ttl-reap.yml
+++ b/.github/workflows/spoke-lane-ttl-reap.yml
@@ -1,0 +1,41 @@
+name: spoke-lane-ttl-reap
+
+on:
+  workflow_call:
+    inputs:
+      spoke:
+        type: string
+        required: true
+      domain:
+        type: string
+        required: true
+      dry_run:
+        type: boolean
+        default: false
+      blahaj_repository:
+        type: string
+        default: tinyland-inc/blahaj
+      dry_run_only:
+        type: boolean
+        default: false
+    secrets:
+      BLAHAJ_DISPATCH_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch expired lane reap
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: tinyland-inc/ci-templates/.github/actions/lane-ttl-reap@v1
+        with:
+          spoke: ${{ inputs.spoke }}
+          domain: ${{ inputs.domain }}
+          dry_run: ${{ inputs.dry_run }}
+          blahaj_repository: ${{ inputs.blahaj_repository }}
+          dry_run_only: ${{ inputs.dry_run_only }}
+          dispatch_token: ${{ secrets.BLAHAJ_DISPATCH_TOKEN }}

--- a/.github/workflows/spoke-lane-ttl-reap.yml
+++ b/.github/workflows/spoke-lane-ttl-reap.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: tinyland-inc/ci-templates/.github/actions/lane-ttl-reap@v1
+      - uses: tinyland-inc/ci-templates/.github/actions/lane-ttl-reap@v2
         with:
           spoke: ${{ inputs.spoke }}
           domain: ${{ inputs.domain }}

--- a/.github/workflows/spoke-public-preview.yml
+++ b/.github/workflows/spoke-public-preview.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: tinyland-inc/ci-templates/.github/actions/public-preview-dispatch@v1
+      - uses: tinyland-inc/ci-templates/.github/actions/public-preview-dispatch@v2
         with:
           operation: ${{ inputs.operation }}
           spoke: ${{ inputs.spoke }}

--- a/.github/workflows/spoke-public-preview.yml
+++ b/.github/workflows/spoke-public-preview.yml
@@ -1,0 +1,85 @@
+name: spoke-public-preview
+
+on:
+  workflow_call:
+    inputs:
+      operation:
+        type: string
+        default: provision
+      spoke:
+        type: string
+        required: true
+      source_repository:
+        type: string
+        required: true
+      source_pr:
+        type: number
+        required: true
+      source_commit:
+        type: string
+        required: true
+      lane:
+        type: string
+        required: true
+      origin_fqdn:
+        type: string
+        required: true
+      origin_service:
+        type: string
+        default: ""
+      origin_host_header:
+        type: string
+        default: ""
+      preview_hostname:
+        type: string
+        required: true
+      ttl_hours:
+        type: number
+        default: 72
+      description:
+        type: string
+        default: ""
+      allow_emails_json:
+        type: string
+        default: "[]"
+      allow_email_domains_json:
+        type: string
+        default: "[]"
+      blahaj_repository:
+        type: string
+        default: tinyland-inc/blahaj
+      dry_run:
+        type: boolean
+        default: false
+    secrets:
+      BLAHAJ_DISPATCH_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch public preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: tinyland-inc/ci-templates/.github/actions/public-preview-dispatch@v1
+        with:
+          operation: ${{ inputs.operation }}
+          spoke: ${{ inputs.spoke }}
+          source_repository: ${{ inputs.source_repository }}
+          source_pr: ${{ inputs.source_pr }}
+          source_commit: ${{ inputs.source_commit }}
+          lane: ${{ inputs.lane }}
+          origin_fqdn: ${{ inputs.origin_fqdn }}
+          origin_service: ${{ inputs.origin_service }}
+          origin_host_header: ${{ inputs.origin_host_header }}
+          preview_hostname: ${{ inputs.preview_hostname }}
+          ttl_hours: ${{ inputs.ttl_hours }}
+          description: ${{ inputs.description }}
+          allow_emails_json: ${{ inputs.allow_emails_json }}
+          allow_email_domains_json: ${{ inputs.allow_email_domains_json }}
+          blahaj_repository: ${{ inputs.blahaj_repository }}
+          dispatch_token: ${{ secrets.BLAHAJ_DISPATCH_TOKEN }}
+          dry_run: ${{ inputs.dry_run }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,52 @@
+title = "ci-templates gitleaks config"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Template and example files may contain documented placeholder values."
+paths = [
+  '''(^|/)\.env\.example$''',
+  '''(^|/).*\.example\.(json|ya?ml|toml|env|txt)$''',
+  '''(^|/).*\.template$''',
+  '''(^|/).*\.sample$''',
+]
+
+[[allowlists]]
+description = "Known non-secret infrastructure literals."
+regexTarget = "line"
+regexes = [
+  '''/nix/store/[a-z0-9]{32}-''',
+  '''age1[a-z0-9]{58}''',
+  '''\{\{\s*vault_[A-Za-z0-9_]+''',
+  '''vault_[A-Za-z0-9_]+\s*[:=]\s*["']?\{\{''',
+  '''\$2[ayb]\$10\$placeholder''',
+]
+
+[[rules]]
+id = "tinyland-cloudflare-api-token"
+description = "Cloudflare API token with cfat_ prefix"
+regex = '''cfat_[A-Za-z0-9]{40,}'''
+keywords = ["cfat_"]
+tags = ["cloudflare", "tinyland"]
+
+[[rules]]
+id = "tinyland-porkbun-api-key"
+description = "Porkbun API key with pk1_ or sk1_ prefix"
+regex = '''(pk1|sk1)_[A-Za-z0-9]{60,}'''
+keywords = ["pk1_", "sk1_"]
+tags = ["porkbun", "tinyland"]
+
+[[rules]]
+id = "tinyland-age-secret-key"
+description = "age secret key"
+regex = '''AGE-SECRET-KEY-1[A-Z0-9]{58,}'''
+keywords = ["AGE-SECRET-KEY-1"]
+tags = ["age", "sops", "tinyland"]
+
+[[rules]]
+id = "tinyland-tailscale-auth-key"
+description = "Tailscale auth, API, or client key"
+regex = '''tskey-(auth|api|client)-[A-Za-z0-9-]{40,}'''
+keywords = ["tskey-"]
+tags = ["tailscale", "tinyland"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`public-preview-dispatch` composite + `spoke-public-preview.yml`** —
+  reusable dispatch path for explicit public/client review aliases. The payload
+  is schema-validated and carries source repo, PR, commit, lane, origin host,
+  preview hostname, TTL, and Cloudflare Access allowlist. Spokes request the
+  alias; Blahaj owns DNS, Access, Tunnel ingress, and cleanup.
+- **`lane-ttl-reap` composite + `spoke-lane-ttl-reap.yml`** — reusable
+  scheduled TTL backstop dispatcher. Blahaj owns listing and idempotent
+  destruction of expired lane environments.
+- **`flywheel-reapi-proof` composite** — reusable dispatcher for
+  GloriousFlywheel executor-backed proof workflows. The composite does not
+  promote target classes by itself; GF proof artifacts remain authoritative.
+- **Public preview and TTL reap schemas** — vendored from the site.scaffold
+  contract alongside the existing lane schemas.
+
 ### Fixed (v1.1.5)
 
 - **`lane-status-check` composite — use `curl` instead of `gh api`** —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ### Added
 
+- **`inherit-scaffold-skills` composite** — pulls
+  `plugins/scaffold-core` from `tinyland-inc/site.scaffold` at a pinned tag or
+  commit SHA, dereferences skill symlinks, and can materialize
+  `.agents/skills` plus `.claude/skills` in consumer spokes. Branch refs such
+  as `main` are rejected by default so inherited AX contracts do not drift
+  silently.
+- **v1 to v2 migration guide** — documents endpoint-free Flywheel behavior,
+  scaffold skills inheritance, v2 internal refs, and rollback posture.
 - **`public-preview-dispatch` composite + `spoke-public-preview.yml`** —
   reusable dispatch path for explicit public/client review aliases. The payload
   is schema-validated and carries source repo, PR, commit, lane, origin host,
@@ -20,6 +28,36 @@ Versioning: [SemVer 2.0](https://semver.org/).
   promote target classes by itself; GF proof artifacts remain authoritative.
 - **Public preview and TTL reap schemas** — vendored from the site.scaffold
   contract alongside the existing lane schemas.
+- **`repo-manifest-validate` composite + repo manifest schema** — reusable
+  validation for `tinyland.repo.json`, including optional role gating such as
+  `static-spoke,static-spoke-scaffold`.
+- **Repo-local validation contract** — adds `Justfile`, `flake.nix`, and
+  `tinyland.repo.json` so this template repo can validate itself the same way
+  consuming repos do. `just check` now parses workflow/action YAML, parses
+  vendored schemas, validates the repo manifest, checks v2 internal refs, and
+  enforces endpoint-free Flywheel defaults plus the canonical Tinyland gitleaks
+  working-tree scan.
+
+### Changed
+
+- **Flywheel Bazel binding is endpoint-free** — `bazelrc/flywheel.bazelrc`
+  no longer hard-codes `remote_cache`, `remote_executor`, or cache upload
+  authority. `flywheel-bazel` now passes `--remote_cache` and
+  `--remote_executor` from runtime env/action inputs and fails fast when the
+  required endpoint is absent.
+- **Reusable workflow internal refs target v2** — v2 workflows and nested
+  composites call sibling ci-templates actions through `@v2`, not `@v1`, so a
+  `spoke-ci.yml@v2.0.0` consumer receives the endpoint-free Flywheel and
+  manifest-validation behavior from the same major release.
+- **Internal action refs no longer use `@main`** — nested ci-templates action
+  calls now use the current floating major tag, and consumer docs point at
+  immutable release tags.
+- **Schema validators can fall back to the consumer Nix dev shell** —
+  `lanes-load` and `repo-manifest-validate` use host Python when `jsonschema`
+  is available and otherwise route through `nix develop --command python3`.
+- **`spoke-ci.yml` now validates repo manifests when present** — pre-manifest
+  consumers continue with a notice; repos that ship `tinyland.repo.json` must
+  declare `static-spoke` or `static-spoke-scaffold` for the spoke workflow.
 
 ### Fixed (v1.1.5)
 

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,49 @@
+# ci-templates task runner
+# Use `just <recipe>` locally and `nix develop --command just <recipe>` in CI.
+
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+root := justfile_directory()
+
+_default:
+    @just --list --unsorted
+
+# Run all repository-local validation.
+check: yaml-parse json-parse repo-manifest-validate internal-refs-check endpoint-free-check secrets-scan-dir
+    @echo "ci-templates checks passed."
+
+# Parse all GitHub workflow/action YAML with Ruby's stdlib YAML parser.
+yaml-parse:
+    cd {{ root }} && ruby -e 'require "yaml"; Dir[".github/**/*.{yml,yaml}"].sort.each { |f| YAML.load_file(f); puts "yaml ok: #{f}" }'
+
+# Parse all vendored JSON schemas.
+json-parse:
+    cd {{ root }} && for f in schemas/*.json tinyland.repo.json; do jq empty "$f"; echo "json ok: $f"; done
+
+# Validate tinyland.repo.json against the vendored Tinyland repo manifest schema.
+repo-manifest-validate:
+    cd {{ root }} && if python3 -c 'import jsonschema' >/dev/null 2>&1; then \
+      validator=(python3); \
+    elif command -v nix >/dev/null 2>&1; then \
+      validator=(nix develop --command python3); \
+    else \
+      echo "python jsonschema unavailable and nix missing" >&2; exit 2; \
+    fi; \
+    "${validator[@]}" scripts/validate-ci-templates.py manifest
+
+# Ensure internal ci-templates action refs resolve to checked-in sibling actions.
+internal-refs-check:
+    cd {{ root }} && python3 scripts/validate-ci-templates.py internal-refs
+
+# Ensure the v2 Flywheel bazelrc fragment has no baked endpoints or upload authority.
+endpoint-free-check:
+    cd {{ root }} && ! grep -Eq -- '--remote_cache=|--remote_executor=|--remote_upload_local_results=true|grpc://bazel-cache|grpc://gf-reapi-cell' bazelrc/flywheel.bazelrc
+    @echo "flywheel.bazelrc endpoint-free"
+
+# Scan current files for secrets.
+secrets-scan-dir:
+    cd {{ root }} && gitleaks dir --config .gitleaks.toml --redact --verbose .
+
+# Scan git history for secrets.
+secrets-scan:
+    cd {{ root }} && gitleaks git --config .gitleaks.toml --redact --verbose .

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Spokes spawned from `tinyland-inc/site.scaffold` consume this repo for:
 - **Schema-validated `lanes.json` loading** via `lanes-load`.
 - **Blahaj `repository_dispatch` payload construction** via
   `lane-dispatch` / `lane-reap`.
+- **Public client preview dispatch** via `public-preview-dispatch`;
+  Blahaj owns Cloudflare DNS, Access, Tunnel ingress, and cleanup.
+- **Scheduled expired-lane cleanup dispatch** via `lane-ttl-reap`.
+- **GloriousFlywheel proof dispatch** via `flywheel-reapi-proof`.
 - **Per-lane GitHub commit status checks** via `lane-status-check`.
 
 The full contract spokes conform to is
@@ -68,6 +72,9 @@ Your spoke needs `.github/lanes.json` validating against
 | **`lanes-load`** | Validate + load `.github/lanes.json`. Outputs matrix-ready `lanes_json`. |
 | **`lane-dispatch`** | Emit Blahaj `<spoke>-lane-env` provision payload. Supports `dry_run`. |
 | **`lane-reap`** | Emit Blahaj destroy payload. Idempotent. |
+| **`lane-ttl-reap`** | Emit Blahaj expired-lane sweep payload for scheduled TTL backstops. |
+| **`public-preview-dispatch`** | Emit Blahaj public/client preview payload with Cloudflare Access allowlist. |
+| **`flywheel-reapi-proof`** | Dispatch and optionally await a GloriousFlywheel executor-backed proof run. |
 | **`lane-status-check`** | Post per-lane `ci/lane/<name>` GitHub commit status. |
 | **`pulse-ingest-validate`** | Validate a Pulse / static projection snapshot. |
 
@@ -82,11 +89,15 @@ input/output documentation.
 | `npm-publish.yml` | Pre-existing: hosted-only Node package build + publish. |
 | **`spoke-ci.yml`** | Canonical spoke CI: secrets-scan, lanes-load, per-lane flywheel-bazel build/test, bazel-graph, optional Playwright. |
 | **`spoke-lane-env.yml`** | Canonical PR-env workflow. Replaces hand-rolled `pr-env-lanes.yml`. |
+| **`spoke-lane-ttl-reap.yml`** | Reusable scheduled TTL backstop dispatcher for Blahaj lane cleanup. |
+| **`spoke-public-preview.yml`** | Reusable public/client preview dispatcher for Cloudflare Access-gated aliases. |
 | **`spoke-pulse-ingest.yml`** | Snapshot-refresh PR opener. |
 
 ## Schemas
 
-`schemas/lanes.schema.json` and `schemas/blahaj-dispatch.schema.json`
+`schemas/lanes.schema.json`, `schemas/blahaj-dispatch.schema.json`,
+`schemas/lane-ttl-reap-dispatch.schema.json`, and
+`schemas/public-preview-dispatch.schema.json`
 are vendored from `tinyland-inc/site.scaffold/docs/schemas/`. The
 schema-doc repo is the source of truth; this repo vendors at known
 stable paths so composite actions can `jsonschema` against them.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Reusable GitHub Actions composite actions + reusable workflows for the
 Tinyland CI house style.
 
-> ⚠️ **Pin to `@v1.0.0` or later.** `@main` is the develop branch and
+> ⚠️ **Pin to an immutable release tag such as `@v2.0.0`.** `@main` is the develop branch and
 > may break without notice. See [`RELEASING.md`](./RELEASING.md) for the
 > SemVer contract.
 
@@ -16,6 +16,10 @@ Spokes spawned from `tinyland-inc/site.scaffold` consume this repo for:
 - **Static projection snapshot refresh** via `spoke-pulse-ingest.yml`.
 - **GloriousFlywheel REAPI binding** via the `flywheel-bazel` composite
   action.
+- **Scaffold AX/skills inheritance** via `inherit-scaffold-skills`, which
+  pulls `plugins/scaffold-core` from `tinyland-inc/site.scaffold` at a pinned
+  tag.
+- **Repo-shape manifest validation** via `repo-manifest-validate`.
 - **Schema-validated `lanes.json` loading** via `lanes-load`.
 - **Blahaj `repository_dispatch` payload construction** via
   `lane-dispatch` / `lane-reap`.
@@ -34,7 +38,7 @@ The full contract spokes conform to is
 # .github/workflows/ci.yml
 jobs:
   ci:
-    uses: tinyland-inc/ci-templates/.github/workflows/spoke-ci.yml@v1.0.0
+    uses: tinyland-inc/ci-templates/.github/workflows/spoke-ci.yml@v2.0.0
     with:
       flywheel_config: flywheel-executor
       playwright_enabled: true
@@ -49,7 +53,7 @@ on:
 
 jobs:
   lane-env:
-    uses: tinyland-inc/ci-templates/.github/workflows/spoke-lane-env.yml@v1.0.0
+    uses: tinyland-inc/ci-templates/.github/workflows/spoke-lane-env.yml@v2.0.0
     with:
       spoke: my-spoke
       enable_tailnet_qa: false
@@ -58,17 +62,48 @@ jobs:
 ```
 
 Your spoke needs `.github/lanes.json` validating against
-[`schemas/lanes.schema.json`](./schemas/lanes.schema.json).
+[`schemas/lanes.schema.json`](./schemas/lanes.schema.json). New spokes should
+also include `tinyland.repo.json` validating against
+[`schemas/tinyland-repo-manifest.schema.json`](./schemas/tinyland-repo-manifest.schema.json).
+
+To inherit the canonical scaffold agent skills into a spoke:
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: tinyland-inc/ci-templates/.github/actions/inherit-scaffold-skills@v2.0.0
+    with:
+      scaffold_ref: v2026.05.19
+```
+
+`scaffold_ref` must be a pinned scaffold tag, `refs/tags/*`, or a full commit
+SHA. Branch refs such as `main` are rejected by default.
+
+## Local validation
+
+Use the same house-style entrypoint as consuming repos:
+
+```bash
+just check
+nix develop --command just check
+```
+
+The check parses all workflow/action YAML, parses vendored JSON schemas,
+validates `tinyland.repo.json`, verifies v2 internal action refs resolve to
+checked-in sibling actions, asserts `bazelrc/flywheel.bazelrc` remains
+endpoint-free, and runs the canonical Tinyland gitleaks working-tree scan.
 
 ## Composite actions
 
 | Action | Purpose |
 |---|---|
-| `nix-setup` | Configure Nix + cache endpoints. Auto-detects cluster reachability. |
+| `nix-setup` | Configure Nix + cache hints. Does not invent Bazel endpoints. |
 | `nix-build` | Run `nix build` with Attic binary cache. |
 | `greedy-cache` | Start Attic `watch-store` daemon for concurrent push. |
 | `secrets-scan` | TruffleHog + Gitleaks. |
-| **`flywheel-bazel`** | `bazelisk` wrapper with `--config=flywheel[-executor]`. Refuses executor on non-cluster runners. |
+| **`inherit-scaffold-skills`** | Pull `plugins/scaffold-core` from `site.scaffold` at a pinned ref and materialize `.agents/skills` + `.claude/skills`. |
+| **`repo-manifest-validate`** | Validate `tinyland.repo.json` and optionally require repo roles such as `static-spoke`. |
+| **`flywheel-bazel`** | `bazelisk` wrapper with endpoint-free `--config=flywheel[-executor]`. Supplies cache/executor endpoints from runtime env or inputs. Refuses executor on non-cluster runners. |
 | **`lanes-load`** | Validate + load `.github/lanes.json`. Outputs matrix-ready `lanes_json`. |
 | **`lane-dispatch`** | Emit Blahaj `<spoke>-lane-env` provision payload. Supports `dry_run`. |
 | **`lane-reap`** | Emit Blahaj destroy payload. Idempotent. |
@@ -78,8 +113,7 @@ Your spoke needs `.github/lanes.json` validating against
 | **`lane-status-check`** | Post per-lane `ci/lane/<name>` GitHub commit status. |
 | **`pulse-ingest-validate`** | Validate a Pulse / static projection snapshot. |
 
-Bolded actions are new in v1.0.0. See per-action `action.yml` for full
-input/output documentation.
+See per-action `action.yml` files for full input/output documentation.
 
 ## Reusable workflows
 
@@ -95,8 +129,8 @@ input/output documentation.
 
 ## Schemas
 
-`schemas/lanes.schema.json`, `schemas/blahaj-dispatch.schema.json`,
-`schemas/lane-ttl-reap-dispatch.schema.json`, and
+`schemas/tinyland-repo-manifest.schema.json`, `schemas/lanes.schema.json`,
+`schemas/blahaj-dispatch.schema.json`, `schemas/lane-ttl-reap-dispatch.schema.json`, and
 `schemas/public-preview-dispatch.schema.json`
 are vendored from `tinyland-inc/site.scaffold/docs/schemas/`. The
 schema-doc repo is the source of truth; this repo vendors at known
@@ -104,18 +138,22 @@ stable paths so composite actions can `jsonschema` against them.
 
 ## Bazelrc fragment
 
-`bazelrc/flywheel.bazelrc` defines `--config=flywheel` (cache-only) and
-`--config=flywheel-executor` (cache + REAPI executor). The
-`flywheel-bazel` composite installs it at runtime; spokes also vendor a
-copy at `.bazelrc.flywheel` and refresh via `just sync-flywheel-bazelrc`.
+`bazelrc/flywheel.bazelrc` is endpoint-free. It defines safe behavior for
+`--config=flywheel` and `--config=flywheel-executor`, but does not hard-code
+`remote_cache`, `remote_executor`, credentials, headers, or upload authority.
+The `flywheel-bazel` composite installs it at runtime and supplies
+`--remote_cache` from `BAZEL_REMOTE_CACHE`; executor mode additionally requires
+`BAZEL_REMOTE_EXECUTOR`. Pull requests default to read-only cache use unless a
+trusted lane sets `GF_BAZEL_REMOTE_UPLOAD=true`.
 
 ## Contributing
 
 See [`RELEASING.md`](./RELEASING.md) for the release flow and SemVer
 policy. Each PR must amend `## [Unreleased]` in `CHANGELOG.md`. Internal
-composite-to-composite refs must use `@v1` (the floating major tag), not
-`@main`.
+composite-to-composite refs must use the current floating major tag, not
+`@main` or an older major.
 
 ## Migration from `@main`
 
-See [`docs/migration-v0-to-v1.md`](docs/migration-v0-to-v1.md).
+See [`docs/migration-v0-to-v1.md`](docs/migration-v0-to-v1.md) and
+[`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -110,12 +110,23 @@ and may break without notice**.
 
 ## Composite-action internal refs
 
-Composite actions that nest other composites (e.g. `flywheel-bazel`
-calling `nix-setup`) MUST reference siblings by major tag, not `@main`:
+Composite actions and reusable workflows that call sibling composites
+(e.g. `flywheel-bazel` calling `nix-setup`) MUST reference siblings by the
+current major tag, not `@main` or an older major:
 
 ```yaml
-uses: tinyland-inc/ci-templates/.github/actions/nix-setup@v1
+uses: tinyland-inc/ci-templates/.github/actions/nix-setup@v2
 ```
 
-This ensures a `git checkout v1.2.3` of the repo exposes a coherent
-self-referential set of action versions.
+This ensures a `git checkout v2.0.0` of the repo exposes a coherent
+self-referential set of action versions. A v2 reusable workflow must not call
+v1 composites unless the migration guide explicitly documents that compatibility
+boundary.
+
+## Flywheel endpoint discipline
+
+`bazelrc/flywheel.bazelrc` MUST remain endpoint-free. Release checks should
+reject hard-coded `remote_cache`, `remote_executor`, credentials, headers, or
+cache upload authority in that fragment. Runtime authority belongs in
+`BAZEL_REMOTE_CACHE`, `BAZEL_REMOTE_EXECUTOR`, optional auth/header env vars,
+and `GF_BAZEL_REMOTE_UPLOAD`.

--- a/bazelrc/flywheel.bazelrc
+++ b/bazelrc/flywheel.bazelrc
@@ -1,42 +1,36 @@
-# .bazelrc.flywheel — GloriousFlywheel cache + REAPI binding for tinyland spokes
+# .bazelrc.flywheel - endpoint-free GloriousFlywheel behavior for Tinyland consumers.
 #
-# Vendored from tinyland-inc/ci-templates@v1.0.0/bazelrc/flywheel.bazelrc.
-# Refresh via `just sync-flywheel-bazelrc` once the ci-templates v1.0.0
-# tag is published.
+# Vendored by tinyland-inc/ci-templates. Cache and executor endpoints are
+# runtime authority and must be supplied through environment variables or action
+# inputs, then passed as Bazel flags by the flywheel-bazel composite action.
 #
-# See docs/CI-SCHEMA.md §5 for the contract:
-#   --config=flywheel           cache-only, safe from any cluster-reachable runner
-#   --config=flywheel-executor  cache + REAPI executor, proved target classes only,
-#                               cluster runners only (refused by ci-templates'
-#                               flywheel-bazel composite on ubuntu-latest)
+# Do not put deployment-specific endpoints, credentials, auth headers, or cache
+# upload authority in this file.
 #
-# Hard invariants (do not violate):
-#   - Do not promote rustfs to RBE CAS / action-cache authority.
-#   - Do not add OpenTofu (opentofu-validate, opentofu-fmt) to executor mode.
-#   - Do not add developer-server targets (//app:dev) to executor mode.
+# Hard invariants:
 #   - Cache hits are not RBE.
+#   - Current RustFS is not trusted CAS/action-cache/publication authority
+#     until TIN-1147 proves repair or replacement.
+#   - OpenTofu, developer-server, and image-push targets are not executor
+#     eligible through this fragment.
 
-# ─────────────────────────────────────────────────────────────────────────
-# --config=flywheel : remote cache only
-# ─────────────────────────────────────────────────────────────────────────
-common:flywheel --remote_cache=grpc://bazel-cache.nix-cache.svc.cluster.local:9092
-common:flywheel --remote_upload_local_results=true
+# Remote cache behavior. The wrapper/action supplies --remote_cache and upload
+# policy after validating BAZEL_REMOTE_CACHE and GF_BAZEL_REMOTE_UPLOAD.
+common:flywheel --remote_upload_local_results=false
 common:flywheel --remote_local_fallback
 common:flywheel --remote_timeout=60
 
-# ─────────────────────────────────────────────────────────────────────────
-# --config=flywheel-executor : remote executor + remote cache
-# Inherits cache config; adds REAPI executor + worker platform pin.
-# Proved-class target tag filter ensures only allowlisted actions ship.
-# ─────────────────────────────────────────────────────────────────────────
+# Remote executor behavior. The wrapper/action supplies --remote_executor only
+# when executor mode is selected and BAZEL_REMOTE_EXECUTOR is present.
 common:flywheel-executor --config=flywheel
-common:flywheel-executor --remote_executor=grpc://gf-reapi-cell.gf-rbe.svc.cluster.local:8980
 common:flywheel-executor --remote_download_minimal
 common:flywheel-executor --jobs=200
-# Worker platform pin: only the gloriousflywheel-rbe-linux-x86_64 image is proved.
-# Spokes that need a different platform must promote via a GloriousFlywheel PR.
+
+# Worker platform pin: only the GloriousFlywheel Linux x86_64 worker image class
+# is accepted for static spokes until a GloriousFlywheel PR proves another one.
 common:flywheel-executor --extra_execution_platforms=@gloriousflywheel//platforms:linux-x86_64
-# Proved-class gating: only targets tagged `flywheel-eligible` may dispatch.
-# Spoke BUILD.bazel adds `tags = ["flywheel-eligible"]` per-target.
+
+# Proved-class gating: consumers add tags = ["flywheel-eligible"] only for
+# target classes present in the GloriousFlywheel eligibility manifest.
 common:flywheel-executor --build_tag_filters=flywheel-eligible
 common:flywheel-executor --test_tag_filters=flywheel-eligible

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -106,7 +106,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@main
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@v2.0.0
     with:
       runner_mode: repo_owned
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
@@ -140,7 +140,7 @@ on:
 
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@main
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@v2.0.0
     with:
       runner_mode: hosted
       workspace_mode: isolated

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -1,0 +1,76 @@
+# Migrating from `@v1.x` to `@v2.0.0`
+
+`v2.0.0` is the Tinyland spoke-conformance release. It removes endpointful
+Flywheel defaults from the reusable Bazel surface and adds scaffold skills
+inheritance for agent-facing repo setup.
+
+## Mechanical migration
+
+Replace ci-templates workflow and action pins in spoke workflows:
+
+```bash
+find .github -name '*.yml' -print0 \
+  | xargs -0 sed -i.bak 's|tinyland-inc/ci-templates/\([^@]*\)@v1\([.0-9]*\)|tinyland-inc/ci-templates/\1@v2.0.0|g'
+find .github -name '*.bak' -delete
+```
+
+Then run the repo's normal gate:
+
+```bash
+nix develop --command just check
+nix develop --command just conformance
+```
+
+## Flywheel endpoint change
+
+`bazelrc/flywheel.bazelrc` is now endpoint-free. It no longer embeds an
+in-cluster remote cache or remote executor URL.
+
+Runtime authority comes from environment supplied by the spoke wrapper, runner,
+or operator job:
+
+- `BAZEL_REMOTE_CACHE` is required for Flywheel-backed Bazel work.
+- `GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed` uses cache only.
+- `GF_BAZEL_SUBSTRATE_MODE=executor-backed` also requires
+  `BAZEL_REMOTE_EXECUTOR`.
+- `GF_BAZEL_REMOTE_UPLOAD=true` is only for trusted default-branch or operator
+  cache-writing jobs.
+
+Pull-request jobs should keep upload false or unset.
+
+## Scaffold skills inheritance
+
+Static spokes can inherit the scaffold agent/AX package from a pinned
+`site.scaffold` tag:
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: tinyland-inc/ci-templates/.github/actions/inherit-scaffold-skills@v2.0.0
+    with:
+      scaffold_ref: v2026.05.19
+```
+
+The action copies `plugins/scaffold-core`, dereferences skill symlinks so the
+consumer checkout is self-contained, copies skill bodies into `.agents/skills`,
+and creates `.claude/skills` symlinks for Claude Code discovery.
+
+Use `mode: check` when you want CI to fail on stale checked-in inherited skills
+instead of rewriting the workspace.
+
+## Internal action refs
+
+Reusable v2 workflows call sibling ci-templates actions through the floating
+`@v2` major tag. This keeps `spoke-ci.yml@v2.0.0` from accidentally invoking
+older v1 composites.
+
+## Rollback
+
+If v2 introduces an unexpected regression, pin the affected workflow back to
+the latest v1 release while filing the regression against Tinyland:
+
+```yaml
+uses: tinyland-inc/ci-templates/.github/workflows/spoke-ci.yml@v1.1.5
+```
+
+Do not point spokes at `@main` as a rollback path.

--- a/docs/npm-publish.md
+++ b/docs/npm-publish.md
@@ -78,7 +78,7 @@ This is a hosted-only workflow today.
 ```yaml
 jobs:
   publish:
-    uses: tinyland-inc/ci-templates/.github/workflows/npm-publish.yml@main
+    uses: tinyland-inc/ci-templates/.github/workflows/npm-publish.yml@v2.0.0
     with:
       node-versions: '["20", "22"]'
       publish-node-version: "22"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,9 +34,15 @@ Likely: org-level allowlist of repos that may set `lane-ttl/permanent`.
 
 ### `flywheel-reapi-proof` composite
 
-Extract MassageIthaca's bespoke `rbe-proof` job pattern into a reusable
-composite once a second spoke wants it. Currently spoke-local; promotion
-gated on demand.
+Implemented as a dispatcher-only composite. GloriousFlywheel remains the proof
+authority; consumers must cite the GF run/artifact evidence before calling a
+target class proved.
+
+### Public preview overlay
+
+Implemented as a reusable dispatch workflow and composite. Spokes request
+client-review aliases through Blahaj; Cloudflare DNS, Access, Tunnel ingress,
+and expiry cleanup stay out of spoke credentials.
 
 ### Renovate / Dependabot configs
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "tinyland ci-templates validation shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            git
+            gitleaks
+            gh
+            just
+            jq
+            ruby
+            python3
+            python3Packages.jsonschema
+            shellcheck
+          ];
+          shellHook = ''
+            echo "ci-templates dev shell"
+            echo "  just   $(just --version)"
+            echo "  jq     $(jq --version)"
+            echo "  ruby   $(ruby --version | awk '{print $1, $2}')"
+            echo "  python $(python3 --version)"
+          '';
+        };
+      }
+    );
+}

--- a/schemas/blahaj-dispatch.schema.json
+++ b/schemas/blahaj-dispatch.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
-	"$id": "https://raw.githubusercontent.com/tinyland-inc/elders.tinyland.dev/main/docs/schemas/blahaj-dispatch.schema.json",
+	"$id": "https://raw.githubusercontent.com/tinyland-inc/site.scaffold/main/docs/schemas/blahaj-dispatch.schema.json",
 	"title": "Tinyland Blahaj lane-env repository_dispatch payload",
 	"description": "Canonical payload shape for the `<spoke>-lane-env` repository_dispatch event sent from any spoke CI workflow to tinyland-inc/blahaj. One schema with an `operation` discriminator covers both provision and destroy. See docs/CI-SCHEMA.md §4.",
 	"type": "object",

--- a/schemas/lane-ttl-reap-dispatch.schema.json
+++ b/schemas/lane-ttl-reap-dispatch.schema.json
@@ -1,0 +1,39 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://raw.githubusercontent.com/tinyland-inc/site.scaffold/main/docs/schemas/lane-ttl-reap-dispatch.schema.json",
+	"title": "Tinyland lane TTL reap repository_dispatch payload",
+	"description": "Canonical scheduled TTL backstop payload. Spokes request a sweep; Blahaj owns listing and idempotent destruction of expired lane environments.",
+	"type": "object",
+	"required": ["event_type", "client_payload"],
+	"additionalProperties": false,
+	"properties": {
+		"event_type": {
+			"type": "string",
+			"pattern": "^[a-z][a-z0-9-]+-lane-ttl-reap$"
+		},
+		"client_payload": {
+			"type": "object",
+			"required": ["schema_version", "operation", "spoke", "domain", "requested_at", "dry_run"],
+			"additionalProperties": false,
+			"properties": {
+				"schema_version": { "const": 1 },
+				"operation": { "const": "reap-expired" },
+				"spoke": {
+					"type": "string",
+					"pattern": "^[a-z][a-z0-9-]{1,62}$"
+				},
+				"domain": {
+					"type": "string",
+					"format": "hostname"
+				},
+				"requested_at": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"dry_run": {
+					"type": "boolean"
+				}
+			}
+		}
+	}
+}

--- a/schemas/lanes.schema.json
+++ b/schemas/lanes.schema.json
@@ -1,8 +1,8 @@
 {
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
-	"$id": "https://raw.githubusercontent.com/tinyland-inc/elders.tinyland.dev/main/docs/schemas/lanes.schema.json",
+	"$id": "https://raw.githubusercontent.com/tinyland-inc/site.scaffold/main/docs/schemas/lanes.schema.json",
 	"title": "Tinyland Spoke lanes.json",
-	"description": "Normative schema for .github/lanes.json in any repo spawned from tinyland-inc/elders.tinyland.dev. Source of truth for per-spoke CI lane matrix, Blahaj PR-env provisioning, and Flywheel RBE binding. See docs/CI-SCHEMA.md for the full contract.",
+	"description": "Normative schema for .github/lanes.json in any repo spawned from tinyland-inc/site.scaffold. Source of truth for per-spoke CI lane matrix, Blahaj PR-env provisioning, and Flywheel RBE binding. See docs/CI-SCHEMA.md for the full contract.",
 	"type": "object",
 	"required": ["schema_version", "spoke", "lanes"],
 	"additionalProperties": false,

--- a/schemas/public-preview-dispatch.schema.json
+++ b/schemas/public-preview-dispatch.schema.json
@@ -1,0 +1,123 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://raw.githubusercontent.com/tinyland-inc/site.scaffold/main/docs/schemas/public-preview-dispatch.schema.json",
+	"title": "Tinyland public preview repository_dispatch payload",
+	"description": "Canonical payload shape for explicit public/client review aliases. The spoke requests a preview; Blahaj owns Cloudflare DNS, Access, Tunnel ingress, and cleanup.",
+	"type": "object",
+	"required": ["event_type", "client_payload"],
+	"additionalProperties": false,
+	"properties": {
+		"event_type": {
+			"type": "string",
+			"pattern": "^[a-z][a-z0-9-]+-public-preview$"
+		},
+		"client_payload": {
+			"type": "object",
+			"required": [
+				"schema_version",
+				"operation",
+				"spoke",
+				"source_repository",
+				"source_pr",
+				"source_commit",
+				"lane",
+				"origin_fqdn",
+				"preview_hostname",
+				"ttl_hours",
+				"auth"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"schema_version": { "const": 1 },
+				"operation": { "enum": ["provision", "destroy"] },
+				"spoke": {
+					"type": "string",
+					"pattern": "^[a-z][a-z0-9-]{1,62}$"
+				},
+				"source_repository": {
+					"type": "string",
+					"pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+				},
+				"source_pr": {
+					"type": "integer",
+					"minimum": 1
+				},
+				"source_commit": {
+					"type": "string",
+					"pattern": "^[0-9a-f]{40}$"
+				},
+				"lane": {
+					"type": "string",
+					"pattern": "^[a-z][a-z0-9-]{0,63}$"
+				},
+				"origin_fqdn": {
+					"type": "string",
+					"format": "hostname"
+				},
+				"origin_service": {
+					"type": "string"
+				},
+				"origin_host_header": {
+					"type": "string",
+					"format": "hostname"
+				},
+				"preview_hostname": {
+					"type": "string",
+					"format": "hostname"
+				},
+				"ttl_hours": {
+					"type": "integer",
+					"minimum": 1,
+					"maximum": 168,
+					"default": 72
+				},
+				"description": {
+					"type": "string",
+					"maxLength": 240
+				},
+				"auth": {
+					"type": "object",
+					"required": ["provider", "identity_provider", "session_duration"],
+					"additionalProperties": false,
+					"properties": {
+						"provider": { "const": "cloudflare-access" },
+						"identity_provider": { "const": "One-time PIN" },
+						"allow_emails": {
+							"type": "array",
+							"items": {
+								"type": "string",
+								"format": "email"
+							},
+							"uniqueItems": true,
+							"default": []
+						},
+						"allow_email_domains": {
+							"type": "array",
+							"items": {
+								"type": "string",
+								"format": "hostname"
+							},
+							"uniqueItems": true,
+							"default": []
+						},
+						"session_duration": {
+							"type": "string",
+							"pattern": "^[1-9][0-9]*h$",
+							"default": "24h"
+						}
+					},
+					"anyOf": [
+						{
+							"required": ["allow_emails"],
+							"properties": { "allow_emails": { "minItems": 1 } }
+						},
+						{
+							"required": ["allow_email_domains"],
+							"properties": { "allow_email_domains": { "minItems": 1 } }
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/schemas/tinyland-repo-manifest.schema.json
+++ b/schemas/tinyland-repo-manifest.schema.json
@@ -1,0 +1,191 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://raw.githubusercontent.com/tinyland-inc/site.scaffold/main/docs/schemas/tinyland-repo-manifest.schema.json",
+	"title": "Tinyland repo manifest",
+	"description": "Declarative repo-shape manifest for Tinyland repos. This distinguishes org-wide rules from static-spoke, mothership, app/stateful spoke, CI-template, GitOps receiver, and infra-substrate contracts.",
+	"type": "object",
+	"required": ["schema_version", "repo", "taxonomy", "contracts", "boundaries", "authorities", "supply_chain"],
+	"additionalProperties": false,
+	"properties": {
+		"$schema": { "type": "string" },
+		"schema_version": { "const": 1 },
+		"repo": {
+			"type": "object",
+			"required": ["name", "github", "description"],
+			"additionalProperties": false,
+			"properties": {
+				"name": {
+					"type": "string",
+					"pattern": "^[A-Za-z0-9_.-]+$"
+				},
+				"github": {
+					"type": "string",
+					"pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+				},
+				"domain": { "type": "string", "format": "hostname" },
+				"description": { "type": "string", "minLength": 12 },
+				"linear": {
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"initiative": {
+							"type": "string",
+							"pattern": "^[A-Z]+-[0-9]+$"
+						},
+						"issue": {
+							"type": "string",
+							"pattern": "^[A-Z]+-[0-9]+$"
+						}
+					}
+				}
+			}
+		},
+		"taxonomy": {
+			"type": "object",
+			"required": ["primary_role", "layers"],
+			"additionalProperties": false,
+			"properties": {
+				"primary_role": { "$ref": "#/$defs/repoRole" },
+				"spawned_repo_role": { "$ref": "#/$defs/repoRole" },
+				"layers": {
+					"type": "array",
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": { "$ref": "#/$defs/taxonomyLayer" }
+				}
+			}
+		},
+		"contracts": {
+			"type": "object",
+			"required": ["agent_contract", "just", "nix", "github_actions", "secrets_scan", "conformance"],
+			"additionalProperties": false,
+			"properties": {
+				"agent_contract": { "type": "string" },
+				"just": { "type": "string" },
+				"nix": { "type": "string" },
+				"github_actions": { "type": "string" },
+				"secrets_scan": { "enum": ["gitleaks", "none"] },
+				"conformance": { "type": "string" }
+			}
+		},
+		"boundaries": {
+			"type": "object",
+			"required": [
+				"owns_runtime_backend",
+				"owns_auth",
+				"owns_payments",
+				"owns_activitypub_delivery",
+				"owns_live_broker_fetch",
+				"owns_static_projection_ingest",
+				"owns_gitops_apply",
+				"owns_cloudflare_mutation",
+				"owns_bazel_module_authority"
+			],
+			"additionalProperties": false,
+			"properties": {
+				"owns_runtime_backend": { "type": "boolean" },
+				"owns_auth": { "type": "boolean" },
+				"owns_payments": { "type": "boolean" },
+				"owns_activitypub_delivery": { "type": "boolean" },
+				"owns_live_broker_fetch": { "type": "boolean" },
+				"owns_static_projection_ingest": { "type": "boolean" },
+				"owns_gitops_apply": { "type": "boolean" },
+				"owns_cloudflare_mutation": { "type": "boolean" },
+				"owns_bazel_module_authority": { "type": "boolean" }
+			}
+		},
+		"authorities": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"content_authority": { "type": "string" },
+				"gitops_receiver": { "type": "string" },
+				"ci_templates": { "type": "string" },
+				"cache_rbe_authority": { "type": "string" },
+				"tofu_module_authority": { "type": "string" },
+				"package_registry": { "type": "string" }
+			}
+		},
+		"supply_chain": {
+			"type": "object",
+			"required": ["sbom"],
+			"additionalProperties": false,
+			"properties": {
+				"sbom": {
+					"type": "object",
+					"required": ["status", "formats"],
+					"additionalProperties": false,
+					"properties": {
+						"status": {
+							"enum": ["not-required", "planned", "recipe-available", "generated"]
+						},
+						"formats": {
+							"type": "array",
+							"uniqueItems": true,
+							"items": { "enum": ["CycloneDX JSON", "SPDX JSON"] }
+						},
+						"notes": { "type": "string" }
+					}
+				}
+			}
+		}
+	},
+	"allOf": [
+		{
+			"if": {
+				"properties": {
+					"taxonomy": {
+						"properties": {
+							"primary_role": {
+								"enum": ["static-spoke", "static-spoke-scaffold"]
+							}
+						}
+					}
+				}
+			},
+			"then": {
+				"properties": {
+					"boundaries": {
+						"properties": {
+							"owns_runtime_backend": { "const": false },
+							"owns_auth": { "const": false },
+							"owns_payments": { "const": false },
+							"owns_activitypub_delivery": { "const": false },
+							"owns_live_broker_fetch": { "const": false },
+							"owns_gitops_apply": { "const": false },
+							"owns_cloudflare_mutation": { "const": false }
+						}
+					}
+				}
+			}
+		}
+	],
+	"$defs": {
+		"repoRole": {
+			"enum": [
+				"static-spoke-scaffold",
+				"static-spoke",
+				"mothership",
+				"app-stateful-spoke",
+				"package-producer",
+				"package-consumer",
+				"ci-template-library",
+				"gitops-receiver",
+				"infra-substrate",
+				"org-utility"
+			]
+		},
+		"taxonomyLayer": {
+			"enum": [
+				"org-wide-repo-contract",
+				"bazel-package-cache-rbe",
+				"static-spoke",
+				"mothership",
+				"app-stateful-spoke",
+				"gitops-receiver",
+				"ci-template-library",
+				"infra-substrate"
+			]
+		}
+	}
+}

--- a/scripts/validate-ci-templates.py
+++ b/scripts/validate-ci-templates.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Repository-local validation helpers for tinyland-inc/ci-templates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def validate_manifest() -> int:
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        print("python jsonschema is unavailable", file=sys.stderr)
+        return 2
+
+    schema_path = ROOT / "schemas/tinyland-repo-manifest.schema.json"
+    manifest_path = ROOT / "tinyland.repo.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(manifest),
+        key=lambda e: list(e.absolute_path),
+    )
+    if errors:
+        for err in errors:
+            path = "/" + "/".join(str(p) for p in err.absolute_path)
+            print(f"{manifest_path.relative_to(ROOT)} {path}: {err.message}", file=sys.stderr)
+        return 1
+    print("tinyland.repo.json valid")
+    return 0
+
+
+def check_internal_refs() -> int:
+    ok = True
+    action_pattern = re.compile(r"tinyland-inc/ci-templates/\.github/actions/([^@\s]+)@v2\b")
+    main_pattern = re.compile(r"tinyland-inc/ci-templates/.*@main")
+
+    for path in sorted((ROOT / ".github").glob("**/*.yml")):
+        text = path.read_text(encoding="utf-8")
+        rel = path.relative_to(ROOT)
+        for action in action_pattern.findall(text):
+            action_yml = ROOT / ".github/actions" / action / "action.yml"
+            if not action_yml.exists():
+                print(f"{rel}: missing internal action {action_yml.relative_to(ROOT)}", file=sys.stderr)
+                ok = False
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            if main_pattern.search(line):
+                print(f"{rel}:{line_no}: internal ci-templates ref uses @main", file=sys.stderr)
+                ok = False
+
+    if not ok:
+        return 1
+    print("internal action refs resolve")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("check", choices=["manifest", "internal-refs"])
+    args = parser.parse_args()
+
+    if args.check == "manifest":
+        return validate_manifest()
+    return check_internal_refs()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tinyland.repo.json
+++ b/tinyland.repo.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "./schemas/tinyland-repo-manifest.schema.json",
+  "schema_version": 1,
+  "repo": {
+    "name": "ci-templates",
+    "github": "tinyland-inc/ci-templates",
+    "description": "Reusable GitHub Actions composites and workflows for Tinyland CI, GitOps lanes, and Flywheel Bazel wiring.",
+    "linear": {
+      "initiative": "TIN-1433",
+      "issue": "TIN-1581"
+    }
+  },
+  "taxonomy": {
+    "primary_role": "ci-template-library",
+    "layers": [
+      "org-wide-repo-contract",
+      "ci-template-library",
+      "bazel-package-cache-rbe",
+      "gitops-receiver"
+    ]
+  },
+  "contracts": {
+    "agent_contract": "README.md and RELEASING.md",
+    "just": "Justfile",
+    "nix": "flake.nix",
+    "github_actions": ".github/actions and .github/workflows",
+    "secrets_scan": "gitleaks",
+    "conformance": "just check"
+  },
+  "boundaries": {
+    "owns_runtime_backend": false,
+    "owns_auth": false,
+    "owns_payments": false,
+    "owns_activitypub_delivery": false,
+    "owns_live_broker_fetch": false,
+    "owns_static_projection_ingest": false,
+    "owns_gitops_apply": false,
+    "owns_cloudflare_mutation": false,
+    "owns_bazel_module_authority": false
+  },
+  "authorities": {
+    "content_authority": "tinyland.dev",
+    "gitops_receiver": "tinyland-inc/blahaj",
+    "ci_templates": "tinyland-inc/ci-templates",
+    "cache_rbe_authority": "tinyland-inc/GloriousFlywheel",
+    "tofu_module_authority": "tinyland-inc/GloriousFlywheel",
+    "package_registry": "tinyland-inc/bazel-registry"
+  },
+  "supply_chain": {
+    "sbom": {
+      "status": "not-required",
+      "formats": [],
+      "notes": "This repository publishes workflow and composite-action source rather than application artifacts."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Prepares `tinyland-inc/ci-templates` for the v2 spoke-conformance contract.

- makes `bazelrc/flywheel.bazelrc` endpoint-free and moves `remote_cache` / `remote_executor` authority into `flywheel-bazel` runtime env or inputs
- adds `inherit-scaffold-skills` so spokes can inherit `plugins/scaffold-core`, `.agents/skills`, and `.claude/skills` from a pinned `site.scaffold` tag
- adds `repo-manifest-validate` plus the vendored `tinyland.repo.json` schema and optional static-spoke role gating in `spoke-ci.yml`
- adds repo-local `Justfile`, `flake.nix`, `flake.lock`, `tinyland.repo.json`, and validation helper so ci-templates validates like consuming repos
- documents `@v1` to `@v2.0.0` migration, internal `@v2` refs, endpoint discipline, and gitleaks local scanning

## Why

This reduces per-spoke CI noise by putting the reusable contract in one place: ci-templates owns reusable workflows/composites, site.scaffold owns the agent/static-spoke contract, Blahaj owns PR lane/public preview dispatch, and GloriousFlywheel owns cache/RBE eligibility.

## Validation

- `just check`
- `nix develop --command just check`

Both include YAML parsing, JSON/schema parsing, `tinyland.repo.json` validation, internal ci-template ref checks, endpoint-free Flywheel checks, and gitleaks working-tree scan.

## Related

- tinyland-inc/site.scaffold#13
- TIN-1581
