### PR TITLE
release: v2.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Assert ## [Unreleased] is non-empty
         run: |
           set -euo pipefail
+          subject=$(git log -1 --pretty=%s "${{ github.event.pull_request.head.sha }}")
+          if [[ "$subject" =~ ^release:\ v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "::notice::release PR detected ($subject); allowing empty ## [Unreleased]"
+            exit 0
+          fi
           if [ ! -f CHANGELOG.md ]; then
             echo "::error::CHANGELOG.md missing"
             exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0] — 2026-05-20
+
 ### Added
 
 - **`inherit-scaffold-skills` composite** — pulls
@@ -58,6 +60,9 @@ Versioning: [SemVer 2.0](https://semver.org/).
 - **`spoke-ci.yml` now validates repo manifests when present** — pre-manifest
   consumers continue with a notice; repos that ship `tinyland.repo.json` must
   declare `static-spoke` or `static-spoke-scaffold` for the spoke workflow.
+- **Release PRs may carry an empty Unreleased section** — `release: vX.Y.Z`
+  PRs are allowed through the changelog gate when branch protection blocks the
+  workflow-driven direct push release path.
 
 ### Fixed (v1.1.5)
 


### PR DESCRIPTION
## Summary

Cut the ci-templates v2.0.0 release section from the current Unreleased changelog.

This PR exists because direct push to protected main is blocked locally. It should be rebase-merged, not squash-merged, so the resulting main HEAD keeps the exact subject `release: v2.0.0` that `.github/workflows/release.yml` uses to cut the immutable `v2.0.0` tag and floating `v2` tag.

## Validation

- `just check`
