### PR TITLE
feat(js-bazel): make npmjs publish policy explicit

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -100,6 +100,10 @@ on:
         description: "When true, request npm provenance for npmjs publishes when supported"
         type: boolean
         default: true
+      npm_publish_mode:
+        description: "npmjs publication policy: required, optional, or disabled"
+        type: string
+        default: "required"
       npm_registry_url:
         description: "npm registry URL for publication"
         type: string
@@ -237,6 +241,7 @@ jobs:
           RUNNER_LABELS_JSON: ${{ inputs.runner_labels_json }}
           WORKSPACE_MODE: ${{ inputs.workspace_mode }}
           PUBLISH_MODE: ${{ inputs.publish_mode }}
+          NPM_PUBLISH_MODE: ${{ inputs.npm_publish_mode }}
           BAZEL_FETCH_RETRY_ATTEMPTS: ${{ inputs.bazel_fetch_retry_attempts || '3' }}
         run: |
           set -euo pipefail
@@ -258,6 +263,13 @@ jobs:
             same_runner|hosted_exception) ;;
             *)
               echo "Unsupported publish_mode: $PUBLISH_MODE" >&2
+              exit 1
+              ;;
+          esac
+          case "$NPM_PUBLISH_MODE" in
+            required|optional|disabled) ;;
+            *)
+              echo "Unsupported npm_publish_mode: $NPM_PUBLISH_MODE" >&2
               exit 1
               ;;
           esac
@@ -577,9 +589,11 @@ jobs:
           npm pack --dry-run "$PACKAGE_DIR"
 
       - name: Validate npm publish dry-run from Bazel artifact
+        if: ${{ inputs.npm_publish_mode != 'disabled' }}
         shell: bash
         env:
           NPM_ACCESS: ${{ inputs.npm_access || 'public' }}
+          NPM_PUBLISH_MODE: ${{ inputs.npm_publish_mode || 'required' }}
           PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
         run: |
           set -euo pipefail
@@ -592,6 +606,8 @@ jobs:
           if [ "$dry_run_status" -ne 0 ]; then
             if grep -Fq "You cannot publish over the previously published versions" <<<"$dry_run_output"; then
               echo "::notice::Skipping npm publish dry-run because this exact package version already exists in npm."
+            elif [ "$NPM_PUBLISH_MODE" = "optional" ]; then
+              echo "::warning::npmjs publish dry-run failed, but npm_publish_mode=optional makes npmjs non-blocking."
             else
               exit "$dry_run_status"
             fi
@@ -646,13 +662,15 @@ jobs:
     needs:
       - resolve-runner
       - validate
-    if: ${{ inputs.dry_run == false || (inputs.publish_on_tag == true && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) }}
+    if: ${{ inputs.npm_publish_mode != 'disabled' && (inputs.dry_run == false || (inputs.publish_on_tag == true && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))) }}
     runs-on: ${{ fromJson(needs.resolve-runner.outputs.publish_runner_labels_json) }}
     timeout-minutes: 20
     steps:
-      - name: Validate publish contract
+      - name: Resolve npmjs publish policy
+        id: npm-policy
         shell: bash
         env:
+          NPM_PUBLISH_MODE: ${{ inputs.npm_publish_mode || 'required' }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
@@ -663,26 +681,46 @@ jobs:
               exit 1
               ;;
           esac
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "NPM_TOKEN is required for npmjs publication." >&2
-            exit 1
-          fi
+          case "$NPM_PUBLISH_MODE" in
+            required)
+              if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+                echo "NPM_TOKEN is required for npmjs publication." >&2
+                exit 1
+              fi
+              echo "should_publish=true" >> "$GITHUB_OUTPUT"
+              ;;
+            optional)
+              if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+                echo "::notice::Skipping npmjs publication because npm_publish_mode=optional and NPM_TOKEN is absent."
+                echo "should_publish=false" >> "$GITHUB_OUTPUT"
+              else
+                echo "should_publish=true" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            *)
+              echo "Unsupported npm_publish_mode: $NPM_PUBLISH_MODE" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Configure self-hosted cache contract
-        if: ${{ runner.environment != 'github-hosted' }}
+        if: ${{ steps.npm-policy.outputs.should_publish == 'true' && runner.environment != 'github-hosted' }}
         uses: tinyland-inc/ci-templates/.github/actions/nix-setup@v2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        if: ${{ steps.npm-policy.outputs.should_publish == 'true' }}
         with:
           node-version: ${{ inputs.publish_node_version || '22' }}
           registry-url: ${{ inputs.npm_registry_url || 'https://registry.npmjs.org' }}
 
       - name: Download Bazel package artifact
+        if: ${{ steps.npm-policy.outputs.should_publish == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bazel-pkg
 
       - name: Extract Bazel package artifact into isolated publish workspace
+        if: ${{ steps.npm-policy.outputs.should_publish == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -693,10 +731,12 @@ jobs:
           echo "PUBLISH_ROOT=$PUBLISH_ROOT" >> "$GITHUB_ENV"
 
       - name: Publish npm artifact
+        if: ${{ steps.npm-policy.outputs.should_publish == 'true' }}
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_ACCESS: ${{ inputs.npm_access || 'public' }}
+          NPM_PUBLISH_MODE: ${{ inputs.npm_publish_mode || 'required' }}
           NPM_REGISTRY_URL: ${{ inputs.npm_registry_url || 'https://registry.npmjs.org' }}
           PACKAGE_DIR: ${{ inputs.package_dir || './bazel-bin/pkg' }}
           RUNNER_ENVIRONMENT: ${{ runner.environment }}
@@ -719,7 +759,15 @@ jobs:
           if [ "${{ inputs.npm_publish_provenance }}" = "true" ] && [ "$RUNNER_ENVIRONMENT" != "self-hosted" ]; then
             PUBLISH_ARGS+=(--provenance)
           fi
+          set +e
           npm publish "${PUBLISH_ARGS[@]}"
+          publish_status="$?"
+          set -e
+          if [ "$publish_status" -ne 0 ] && [ "$NPM_PUBLISH_MODE" = "optional" ]; then
+            echo "::warning::npmjs publish failed, but npm_publish_mode=optional makes npmjs non-blocking."
+            exit 0
+          fi
+          exit "$publish_status"
 
   publish-github:
     needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`js-bazel-package.yml` npmjs policy is explicit** — adds
+  `npm_publish_mode=required|optional|disabled`. The default remains
+  `required` for existing consumers, while Bazel-first packages can make
+  npmjs best-effort or disabled when GitHub Packages and the Tinyland Bazel
+  registry are the release authority.
+
 ## [2.0.0] — 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See per-action `action.yml` files for full input/output documentation.
 
 | Workflow | Purpose |
 |---|---|
-| `js-bazel-package.yml` | Pre-existing: JS/TS packages built by Bazel and published to npm/GHCR. |
+| `js-bazel-package.yml` | Pre-existing: JS/TS packages built by Bazel and published to GitHub Packages, with npmjs required/optional/disabled by package policy. |
 | `npm-publish.yml` | Pre-existing: hosted-only Node package build + publish. |
 | **`spoke-ci.yml`** | Canonical spoke CI: secrets-scan, lanes-load, per-lane flywheel-bazel build/test, bazel-graph, optional Playwright. |
 | **`spoke-lane-env.yml`** | Canonical PR-env workflow. Replaces hand-rolled `pr-env-lanes.yml`. |

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -15,6 +15,7 @@ It is meant for packages like:
 - makes runner intent explicit with `runner_mode`
 - makes workspace hygiene explicit with `workspace_mode`
 - makes publish authority explicit with `publish_mode`
+- makes npmjs authority explicit with `npm_publish_mode`
 - installs the workspace with pnpm
 - configures Attic and Bazel cache hints on self-hosted runners
 - optionally keeps legacy cleanup-based workspace behavior for migration
@@ -22,7 +23,8 @@ It is meant for packages like:
 - runs optional metadata, lint, typecheck, unit, and integration commands
 - builds the workspace artifact
 - validates the Bazel-built package via `npm pack --dry-run`
-- validates npm publish dry-runs against the Bazel artifact
+- validates npm publish dry-runs against the Bazel artifact unless npmjs is
+  disabled
 - optionally validates GitHub Packages dry-runs after rewriting package metadata
 - uploads the Bazel-built package artifact for publish jobs
 - publishes from the same runner class or from an explicit hosted exception path
@@ -81,6 +83,30 @@ Meaning:
   - validate on the chosen runner class
   - publish from `ubuntu-latest` intentionally after artifact handoff
 
+### `npm_publish_mode`
+
+Allowed values:
+
+- `required`
+- `optional`
+- `disabled`
+
+Meaning:
+
+- `required`
+  - preserve the legacy npmjs contract
+  - validate npmjs dry-runs
+  - require `secrets.NPM_TOKEN` before real npmjs publication
+  - fail the workflow when npmjs publish fails
+- `optional`
+  - keep npmjs validation and publication as best-effort compatibility
+  - skip real npmjs publication when `secrets.NPM_TOKEN` is absent
+  - warn, but do not fail, when npmjs dry-run or publish fails
+- `disabled`
+  - skip npmjs dry-run validation and npmjs publication
+  - use this for Bazel-first packages whose release authority is GitHub
+    tag/release, GitHub Packages, and the Tinyland Bazel registry
+
 ### `github_package_name`
 
 `github_package_name` is the package coordinate used only for the GitHub
@@ -123,6 +149,7 @@ jobs:
       bazel_targets: "//:typecheck //:pkg //:test"
       package_dir: ./bazel-bin/pkg
       github_package_name: "@jesssullivan/scheduling-kit"
+      npm_publish_mode: required
       dry_run: true
       publish_on_tag: true
     secrets: inherit
@@ -151,6 +178,8 @@ jobs:
       build_command: pnpm build
       bazel_targets: "//:pkg"
       package_dir: ./bazel-bin/pkg
+      github_package_name: "@tinyland-inc/tinyland-auth-redis"
+      npm_publish_mode: disabled
       dry_run: true
       publish_on_tag: true
 ```
@@ -174,8 +203,10 @@ jobs:
 - `dry_run: true` keeps pull requests and branch pushes in validation-only mode.
   Set `publish_on_tag: true` in package repositories that should publish the
   Bazel artifact when the caller workflow is triggered by a `push` to `refs/tags/v*`.
-  The caller workflow must include an `on.push.tags` trigger, and npmjs
-  publication still requires `secrets.NPM_TOKEN`.
+  The caller workflow must include an `on.push.tags` trigger. npmjs publication
+  requires `secrets.NPM_TOKEN` only when `npm_publish_mode=required`; Bazel-first
+  packages should use `optional` or `disabled` when GitHub Packages and the
+  Bazel registry are the release authority.
 - self-hosted jobs now call `nix-setup`, so Attic and Bazel cache hints are
   explicit instead of incidental runner state.
 - `workspace_mode=isolated` is the preferred contract for downstream pilots.
@@ -184,14 +215,17 @@ jobs:
 - publish jobs always extract into an isolated temp directory, even when the
   validation workspace stays in compatibility mode.
 - npmjs publication still requests provenance on hosted runners and skips it on
-  self-hosted runners when needed.
+  self-hosted runners when needed, but only when `npm_publish_mode` allows an
+  npmjs publish attempt.
 - real publish jobs are idempotent for already-published package versions. After
   extracting the Bazel artifact, the npmjs and GitHub Packages jobs check
   whether the exact `name@version` already exists in the target registry and
   skip only that duplicate-version case. Registry lookup failures or absent
   versions still fall through to `npm publish` so permission and package errors
-  remain visible.
+  remain visible unless `npm_publish_mode=optional`.
 - npm publish dry-run validation also treats npm's duplicate-version rejection
   as an idempotent pass. Newer npm versions may reject `npm publish --dry-run`
   for an already-published version even though the preceding `npm pack`
-  validation proved the package artifact shape.
+  validation proved the package artifact shape. Use `npm_publish_mode=disabled`
+  to skip npmjs dry-run validation entirely for Bazel-first packages with no
+  npmjs release target.


### PR DESCRIPTION
## Summary
- add npm_publish_mode=required|optional|disabled to js-bazel-package.yml
- keep required as the default for backwards compatibility
- let Bazel-first packages disable or best-effort npmjs while GitHub Packages remains independent
- document the policy and update the hosted example for tinyland-auth-redis-style packages

## Validation
- actionlint .github/workflows/js-bazel-package.yml
- python3 scripts/validate-ci-templates.py internal-refs
- nix develop --command python3 scripts/validate-ci-templates.py manifest
- git diff --check

Repo-wide actionlint still reports pre-existing custom runner label warnings outside js-bazel-package.yml.