### PR TITLE
fix(js-bazel): guard empty shared runner labels

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -165,12 +165,19 @@ jobs:
 
           runner_mode = os.environ.get("RUNNER_MODE") or "compat"
           publish_mode = os.environ.get("PUBLISH_MODE") or "same_runner"
+          shared_runner_labels_raw = os.environ.get("SHARED_RUNNER_LABELS_JSON")
 
           if runner_mode not in {"compat", "hosted", "shared", "repo_owned"}:
               raise SystemExit(f"Unsupported runner_mode: {runner_mode}")
 
           if publish_mode not in {"same_runner", "hosted_exception"}:
               raise SystemExit(f"Unsupported publish_mode: {publish_mode}")
+
+          if runner_mode == "shared" and shared_runner_labels_raw is not None and not shared_runner_labels_raw.strip():
+              raise SystemExit(
+                  "runner_mode=shared requires shared_runner_labels_json; "
+                  "an empty value usually means the caller repo variable is unset"
+              )
 
           def parse_labels(name: str, fallback: str) -> list[str]:
               raw = os.environ.get(name) or fallback
@@ -239,6 +246,7 @@ jobs:
         env:
           RUNNER_MODE: ${{ inputs.runner_mode }}
           RUNNER_LABELS_JSON: ${{ inputs.runner_labels_json }}
+          SHARED_RUNNER_LABELS_JSON: ${{ inputs.shared_runner_labels_json }}
           WORKSPACE_MODE: ${{ inputs.workspace_mode }}
           PUBLISH_MODE: ${{ inputs.publish_mode }}
           NPM_PUBLISH_MODE: ${{ inputs.npm_publish_mode }}
@@ -273,6 +281,10 @@ jobs:
               exit 1
               ;;
           esac
+          if [ "$RUNNER_MODE" = "shared" ] && [ -z "${SHARED_RUNNER_LABELS_JSON//[[:space:]]/}" ]; then
+            echo "runner_mode=shared requires shared_runner_labels_json; an empty value usually means the caller repo variable is unset" >&2
+            exit 1
+          fi
           case "$BAZEL_FETCH_RETRY_ATTEMPTS" in
             ""|*[!0-9]*)
               echo "bazel_fetch_retry_attempts must be a positive integer" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning: [SemVer 2.0](https://semver.org/).
   `required` for existing consumers, while Bazel-first packages can make
   npmjs best-effort or disabled when GitHub Packages and the Tinyland Bazel
   registry are the release authority.
+- **`js-bazel-package.yml` shared runner labels are guarded** —
+  `runner_mode=shared` now rejects an explicitly empty
+  `shared_runner_labels_json`, catching missing caller repo variables before the
+  workflow silently falls back to the default shared runner class.
 
 ## [2.0.0] — 2026-05-20
 

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -49,6 +49,8 @@ Meaning:
   - validate and publish on GitHub-hosted runners intentionally
 - `shared`
   - validate and publish on a documented shared GloriousFlywheel lane
+  - pass a non-empty `shared_runner_labels_json`; an empty value is rejected
+    because it usually means the caller repo variable is missing
 - `repo_owned`
   - validate and publish on repo-specific runner labels
 
@@ -193,6 +195,12 @@ jobs:
   the selected labels in a small hosted setup job, then passes simple JSON
   outputs into `runs-on` to avoid the complex inline expressions that previously
   caused GitHub Actions startup failures before jobs were created.
+- `runner_mode=shared` rejects an explicitly empty `shared_runner_labels_json`.
+  This catches missing caller repo variables before the workflow silently falls
+  back to the default shared runner class.
+- Package repos that need fork-safe owned capacity should prefer
+  `runner_mode=repo_owned` with explicit `runner_labels_json`. Use `hosted` for
+  packages that do not need cluster-internal REAPI access yet.
 - `bazel_fetch_retry_attempts` defaults to `3` and wraps consumer-provided
   validation commands plus explicit Bazel target validation. It only retries
   when the command log matches transient Bazel external archive fetch failures,


### PR DESCRIPTION
## Summary
- make runner_mode=shared reject an explicitly empty shared_runner_labels_json
- document that empty shared labels usually mean a missing caller repo variable
- add changelog coverage for the guard

This prevents package repos from silently falling back to the default shared tinyland-docker class when vars.PRIMARY_LINUX_RUNNER_LABELS_JSON is unset.

## Validation
- actionlint .github/workflows/js-bazel-package.yml
- python3 scripts/validate-ci-templates.py internal-refs
- nix develop --command python3 scripts/validate-ci-templates.py manifest
- git diff --check