### PR TITLE
fix(js-bazel): enforce capability runner labels

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -13,7 +13,7 @@ on:
         type: string
         default: '["tinyland-docker"]'
       runner_labels_json:
-        description: "JSON array of runner labels used by compat mode and required when runner_mode=repo_owned"
+        description: "JSON array of capability-class runner labels used by compat mode and required when runner_mode=repo_owned"
         type: string
         default: '["ubuntu-latest"]'
       workspace_mode:
@@ -195,6 +195,23 @@ jobs:
 
               return labels
 
+          tinyland_capability_labels = {
+              "tinyland-nix",
+              "tinyland-nix-heavy",
+              "tinyland-nix-kvm",
+              "tinyland-nix-gpu",
+              "tinyland-docker",
+              "tinyland-dind",
+          }
+
+          def require_tinyland_capability(labels: list[str], name: str) -> None:
+              if tinyland_capability_labels.isdisjoint(labels):
+                  allowed = ", ".join(sorted(tinyland_capability_labels))
+                  raise SystemExit(
+                      f"{name} must include a Tinyland capability-class label; "
+                      f"allowed capability labels: {allowed}"
+                  )
+
           runner_labels = parse_labels("RUNNER_LABELS_JSON", '["ubuntu-latest"]')
           shared_runner_labels = parse_labels(
               "SHARED_RUNNER_LABELS_JSON",
@@ -210,6 +227,11 @@ jobs:
 
           if runner_mode == "repo_owned" and validate_runner_labels == ["ubuntu-latest"]:
               raise SystemExit("runner_mode=repo_owned requires explicit runner_labels_json")
+
+          if runner_mode == "repo_owned":
+              require_tinyland_capability(validate_runner_labels, "runner_labels_json")
+          elif runner_mode == "shared":
+              require_tinyland_capability(validate_runner_labels, "shared_runner_labels_json")
 
           if publish_mode == "hosted_exception":
               publish_runner_labels = ["ubuntu-latest"]
@@ -298,6 +320,45 @@ jobs:
           if [ "$RUNNER_MODE" = "repo_owned" ] && [ "$RUNNER_LABELS_JSON" = '["ubuntu-latest"]' ]; then
             echo "runner_mode=repo_owned requires explicit runner_labels_json" >&2
             exit 1
+          fi
+          if [ "$RUNNER_MODE" = "repo_owned" ] || [ "$RUNNER_MODE" = "shared" ]; then
+            if [ "$RUNNER_MODE" = "repo_owned" ]; then
+              labels_json="$RUNNER_LABELS_JSON"
+              labels_name="runner_labels_json"
+            else
+              labels_json="$SHARED_RUNNER_LABELS_JSON"
+              labels_name="shared_runner_labels_json"
+            fi
+            LABELS_JSON="$labels_json" LABELS_NAME="$labels_name" python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          labels_name = os.environ["LABELS_NAME"]
+          labels_raw = os.environ.get("LABELS_JSON") or ""
+          try:
+              labels = json.loads(labels_raw)
+          except json.JSONDecodeError as exc:
+              print(f"{labels_name} must be a JSON array: {exc}", file=sys.stderr)
+              raise SystemExit(1) from exc
+
+          capabilities = {
+              "tinyland-nix",
+              "tinyland-nix-heavy",
+              "tinyland-nix-kvm",
+              "tinyland-nix-gpu",
+              "tinyland-docker",
+              "tinyland-dind",
+          }
+          if not isinstance(labels, list) or capabilities.isdisjoint(labels):
+              allowed = ", ".join(sorted(capabilities))
+              print(
+                  f"{labels_name} must include a Tinyland capability-class label; "
+                  f"allowed capability labels: {allowed}",
+                  file=sys.stderr,
+              )
+              raise SystemExit(1)
+          PY
           fi
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning: [SemVer 2.0](https://semver.org/).
   `runner_mode=shared` now rejects an explicitly empty
   `shared_runner_labels_json`, catching missing caller repo variables before the
   workflow silently falls back to the default shared runner class.
+- **`js-bazel-package.yml` repo-owned mode uses capability labels** —
+  `runner_mode=repo_owned` now requires explicit runner labels that include a
+  Tinyland capability class, and docs clarify that repo ownership is a
+  registration/trust boundary rather than permission to mint repo-shaped labels.
 
 ## [2.0.0] — 2026-05-20
 

--- a/Justfile
+++ b/Justfile
@@ -9,7 +9,7 @@ _default:
     @just --list --unsorted
 
 # Run all repository-local validation.
-check: yaml-parse json-parse repo-manifest-validate internal-refs-check endpoint-free-check secrets-scan-dir
+check: yaml-parse json-parse repo-manifest-validate internal-refs-check js-bazel-runner-contract-check endpoint-free-check secrets-scan-dir
     @echo "ci-templates checks passed."
 
 # Parse all GitHub workflow/action YAML with Ruby's stdlib YAML parser.
@@ -34,6 +34,10 @@ repo-manifest-validate:
 # Ensure internal ci-templates action refs resolve to checked-in sibling actions.
 internal-refs-check:
     cd {{ root }} && python3 scripts/validate-ci-templates.py internal-refs
+
+# Ensure js-bazel-package keeps runner-mode semantics aligned with GloriousFlywheel.
+js-bazel-runner-contract-check:
+    cd {{ root }} && python3 scripts/validate-ci-templates.py js-bazel-runner-contract
 
 # Ensure the v2 Flywheel bazelrc fragment has no baked endpoints or upload authority.
 endpoint-free-check:

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -51,8 +51,17 @@ Meaning:
   - validate and publish on a documented shared GloriousFlywheel lane
   - pass a non-empty `shared_runner_labels_json`; an empty value is rejected
     because it usually means the caller repo variable is missing
+  - labels must include one of the shared Tinyland capability classes
 - `repo_owned`
-  - validate and publish on repo-specific runner labels
+  - validate and publish on a repo/owner-scoped runner registration path
+  - workflow-facing labels still stay shared Tinyland capability classes
+  - labels must include one of the shared Tinyland capability classes
+
+`repo_owned` is a trust and registration boundary, not permission to mint
+repo-shaped runner labels. GloriousFlywheel keeps runner labels capability-based
+(`tinyland-nix`, `tinyland-docker`, and related classes); owner/repo separation
+belongs in ARC registration identity, runner groups, GitHub App installation,
+and implementation-overlay policy.
 
 ### `workspace_mode`
 
@@ -119,7 +128,7 @@ account or organization that owns the package. For a `tinyland-inc/*` repository
 whose public npm package is `@tummycrypt/tinyland-auth`, use a GitHub Packages
 mirror name such as `@tinyland-inc/tinyland-auth`.
 
-## Example: repo-owned self-hosted package path
+## Example: repo-owned capability-class package path
 
 ```yaml
 name: CI
@@ -157,6 +166,12 @@ jobs:
     secrets: inherit
 ```
 
+In that example, `PRIMARY_LINUX_RUNNER_LABELS_JSON` must resolve to a
+capability-shaped label set such as `["self-hosted","linux","tinyland-nix"]`.
+It must not resolve to a repo-shaped label. Pull-request validation remains
+safe for forks because publish jobs are still gated by tag/workflow policy and
+GitHub does not expose protected publish secrets to untrusted fork PRs.
+
 ## Example: hosted template consumer
 
 ```yaml
@@ -190,7 +205,9 @@ jobs:
 
 - `compat` exists only to let existing consumers adopt the new template without
   breaking in one PR.
-- `runner_mode=repo_owned` should always pass explicit `runner_labels_json`.
+- `runner_mode=repo_owned` must pass explicit `runner_labels_json` and that
+  label set must include a Tinyland capability class. It does not authorize
+  repo-shaped labels.
 - `runner_mode=shared` uses `shared_runner_labels_json`. The workflow resolves
   the selected labels in a small hosted setup job, then passes simple JSON
   outputs into `runs-on` to avoid the complex inline expressions that previously
@@ -199,8 +216,9 @@ jobs:
   This catches missing caller repo variables before the workflow silently falls
   back to the default shared runner class.
 - Package repos that need fork-safe owned capacity should prefer
-  `runner_mode=repo_owned` with explicit `runner_labels_json`. Use `hosted` for
-  packages that do not need cluster-internal REAPI access yet.
+  `runner_mode=repo_owned` with explicit capability-shaped
+  `runner_labels_json`. Use `hosted` for packages that do not need
+  cluster-internal REAPI access yet.
 - `bazel_fetch_retry_attempts` defaults to `3` and wraps consumer-provided
   validation commands plus explicit Bazel target validation. It only retries
   when the command log matches transient Bazel external archive fetch failures,

--- a/scripts/validate-ci-templates.py
+++ b/scripts/validate-ci-templates.py
@@ -62,13 +62,69 @@ def check_internal_refs() -> int:
     return 0
 
 
+def check_js_bazel_package_runner_contract() -> int:
+    workflow_path = ROOT / ".github/workflows/js-bazel-package.yml"
+    docs_path = ROOT / "docs/js-bazel-package.md"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    docs = docs_path.read_text(encoding="utf-8")
+
+    required_workflow_snippets = [
+        "runner_mode=repo_owned requires explicit runner_labels_json",
+        "must include a Tinyland capability-class label",
+        '"tinyland-nix"',
+        '"tinyland-docker"',
+        '"tinyland-dind"',
+        "runner_mode=shared requires shared_runner_labels_json",
+    ]
+    required_docs_snippets = [
+        "`repo_owned` is a trust and registration boundary",
+        "workflow-facing labels still stay shared Tinyland capability classes",
+        "It must not resolve to a repo-shaped label.",
+        "forks because publish jobs are still gated by tag/workflow policy",
+    ]
+    forbidden_docs_snippets = [
+        "- validate and publish on repo-specific runner labels",
+        "repo-owned dedicated lane",
+    ]
+
+    ok = True
+    for snippet in required_workflow_snippets:
+        if snippet not in workflow:
+            print(
+                f"{workflow_path.relative_to(ROOT)}: missing runner contract snippet: {snippet}",
+                file=sys.stderr,
+            )
+            ok = False
+    for snippet in required_docs_snippets:
+        if snippet not in docs:
+            print(
+                f"{docs_path.relative_to(ROOT)}: missing runner contract snippet: {snippet}",
+                file=sys.stderr,
+            )
+            ok = False
+    for snippet in forbidden_docs_snippets:
+        if snippet in docs:
+            print(
+                f"{docs_path.relative_to(ROOT)}: stale runner contract snippet remains: {snippet}",
+                file=sys.stderr,
+            )
+            ok = False
+
+    if not ok:
+        return 1
+    print("js-bazel-package runner contract documented and guarded")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("check", choices=["manifest", "internal-refs"])
+    parser.add_argument("check", choices=["manifest", "internal-refs", "js-bazel-runner-contract"])
     args = parser.parse_args()
 
     if args.check == "manifest":
         return validate_manifest()
+    if args.check == "js-bazel-runner-contract":
+        return check_js_bazel_package_runner_contract()
     return check_internal_refs()
 
 


### PR DESCRIPTION
## Summary
- require shared/repo_owned js-bazel-package runner labels to include a Tinyland capability-class label
- clarify that repo_owned is a repo/owner-scoped registration and trust boundary, not repo-shaped workflow labels
- add a repo-local runner-contract check and wire it into `just check`

## Validation
- `python3 scripts/validate-ci-templates.py js-bazel-runner-contract`
- `ruby -e 'require "yaml"; Dir[".github/**/*.{yml,yaml}"].sort.each { |f| YAML.load_file(f); puts "yaml ok: #{f}" }'`
- `actionlint .github/workflows/js-bazel-package.yml`
- `python3 -m py_compile scripts/validate-ci-templates.py`
- `git diff --check`
- `nix develop --command just check`

TIN-1630