### PR TITLE
fix(flywheel): correlate REAPI proof runs by request id

### DIFF
--- a/.github/actions/flywheel-reapi-proof/action.yml
+++ b/.github/actions/flywheel-reapi-proof/action.yml
@@ -34,6 +34,10 @@ inputs:
   consumer_ref:
     description: Consumer commit/ref to prove.
     required: true
+  request_id:
+    description: Unique request id used to correlate this caller with the dispatched GF workflow run. Generated when empty.
+    required: false
+    default: ""
   consumer_checkout_authority:
     description: Checkout authority passed to the GF workflow.
     required: false
@@ -65,6 +69,9 @@ outputs:
   run_url:
     description: Dispatched GF run URL.
     value: ${{ steps.resolve.outputs.run_url }}
+  request_id:
+    description: Unique request id passed to the GF workflow run.
+    value: ${{ steps.dispatch.outputs.request_id }}
 
 runs:
   using: composite
@@ -75,9 +82,20 @@ runs:
       run: |
         set -euo pipefail
         dispatch_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        request_id="${INPUT_REQUEST_ID}"
+        if [ -z "${request_id}" ]; then
+          repo_slug="${GITHUB_REPOSITORY//\//-}"
+          target_slug="$(printf '%s' "${INPUT_TARGET}" | tr -c 'A-Za-z0-9_.-' '-')"
+          action_slug="$(printf '%s' "${GITHUB_ACTION:-action}" | tr -c 'A-Za-z0-9_.-' '-')"
+          nonce="$(date -u +%Y%m%dT%H%M%SZ)-${RANDOM}${RANDOM}"
+          request_id="gf-reapi-${repo_slug}-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}-${GITHUB_JOB:-job}-${action_slug}-${target_slug}-${nonce}"
+        fi
+        request_id="$(printf '%s' "${request_id}" | tr -c 'A-Za-z0-9_.:-' '-')"
+        request_id="${request_id:0:200}"
         gh workflow run "${{ inputs.gf_workflow }}" \
           --repo "${{ inputs.gf_repository }}" \
           --ref "${{ inputs.gf_ref }}" \
+          -f request_id="${request_id}" \
           -f image_digest="${{ inputs.image_digest }}" \
           -f target="${{ inputs.target }}" \
           -f bazel_command="${{ inputs.bazel_command }}" \
@@ -87,9 +105,14 @@ runs:
           -f tinyland_schemas_private_handoff="${{ inputs.tinyland_schemas_private_handoff }}" \
           -f apply="${{ inputs.apply }}" \
           -f force_execution="${{ inputs.force_execution }}"
-        echo "dispatch_time=${dispatch_time}" >> "${GITHUB_OUTPUT}"
+        {
+          echo "dispatch_time=${dispatch_time}"
+          echo "request_id=${request_id}"
+        } >> "${GITHUB_OUTPUT}"
       env:
         GH_TOKEN: ${{ inputs.dispatch_token }}
+        INPUT_REQUEST_ID: ${{ inputs.request_id }}
+        INPUT_TARGET: ${{ inputs.target }}
 
     - name: Resolve dispatched run
       id: resolve
@@ -97,16 +120,24 @@ runs:
       run: |
         set -euo pipefail
         run_id=""
+        request_id="${{ steps.dispatch.outputs.request_id }}"
+        dispatch_time="${{ steps.dispatch.outputs.dispatch_time }}"
         for _ in $(seq 1 60); do
-          run_id="$(
+          runs_json="$(
             gh run list \
               --repo "${{ inputs.gf_repository }}" \
               --workflow "${{ inputs.gf_workflow }}" \
               --event workflow_dispatch \
               --branch "${{ inputs.gf_ref }}" \
-              --limit 20 \
-              --json databaseId,createdAt \
-              --jq "[.[] | select(.createdAt >= \"${{ steps.dispatch.outputs.dispatch_time }}\")] | sort_by(.createdAt, .databaseId) | last | .databaseId // \"\""
+              --limit 50 \
+              --json databaseId,createdAt,displayTitle
+          )"
+          run_id="$(
+            jq -r \
+              --arg dispatch_time "${dispatch_time}" \
+              --arg request_id "${request_id}" \
+              '[.[] | select(.createdAt >= $dispatch_time) | select((.displayTitle // "") | contains($request_id))] | sort_by(.createdAt, .databaseId) | first | .databaseId // ""' \
+              <<< "${runs_json}"
           )"
           if [ -n "${run_id}" ]; then
             break
@@ -122,7 +153,7 @@ runs:
           echo "run_id=${run_id}"
           echo "run_url=${run_url}"
         } >> "${GITHUB_OUTPUT}"
-        echo "::notice::GloriousFlywheel proof run: ${run_url}"
+        echo "::notice::GloriousFlywheel proof run: ${run_url} (request_id=${request_id})"
       env:
         GH_TOKEN: ${{ inputs.dispatch_token }}
 

--- a/Justfile
+++ b/Justfile
@@ -9,7 +9,7 @@ _default:
     @just --list --unsorted
 
 # Run all repository-local validation.
-check: yaml-parse json-parse repo-manifest-validate internal-refs-check js-bazel-runner-contract-check endpoint-free-check secrets-scan-dir
+check: yaml-parse json-parse repo-manifest-validate internal-refs-check js-bazel-runner-contract-check flywheel-reapi-proof-contract-check endpoint-free-check secrets-scan-dir
     @echo "ci-templates checks passed."
 
 # Parse all GitHub workflow/action YAML with Ruby's stdlib YAML parser.
@@ -38,6 +38,10 @@ internal-refs-check:
 # Ensure js-bazel-package keeps runner-mode semantics aligned with GloriousFlywheel.
 js-bazel-runner-contract-check:
     cd {{ root }} && python3 scripts/validate-ci-templates.py js-bazel-runner-contract
+
+# Ensure flywheel-reapi-proof keeps child-run correlation request-id based.
+flywheel-reapi-proof-contract-check:
+    cd {{ root }} && python3 scripts/validate-ci-templates.py flywheel-reapi-proof-contract
 
 # Ensure the v2 Flywheel bazelrc fragment has no baked endpoints or upload authority.
 endpoint-free-check:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ endpoint-free, and runs the canonical Tinyland gitleaks working-tree scan.
 | **`lane-reap`** | Emit Blahaj destroy payload. Idempotent. |
 | **`lane-ttl-reap`** | Emit Blahaj expired-lane sweep payload for scheduled TTL backstops. |
 | **`public-preview-dispatch`** | Emit Blahaj public/client preview payload with Cloudflare Access allowlist. |
-| **`flywheel-reapi-proof`** | Dispatch and optionally await a GloriousFlywheel executor-backed proof run. |
+| **`flywheel-reapi-proof`** | Dispatch and optionally await a GloriousFlywheel executor-backed proof run, correlated by a unique request id. |
 | **`lane-status-check`** | Post per-lane `ci/lane/<name>` GitHub commit status. |
 | **`pulse-ingest-validate`** | Validate a Pulse / static projection snapshot. |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,7 +36,9 @@ Likely: org-level allowlist of repos that may set `lane-ttl/permanent`.
 
 Implemented as a dispatcher-only composite. GloriousFlywheel remains the proof
 authority; consumers must cite the GF run/artifact evidence before calling a
-target class proved.
+target class proved. Dispatch correlation uses a unique request id in the
+GloriousFlywheel workflow run name; timestamp-only child-run resolution is not
+safe under concurrent consumer proofs.
 
 ### Public preview overlay
 

--- a/scripts/validate-ci-templates.py
+++ b/scripts/validate-ci-templates.py
@@ -116,15 +116,84 @@ def check_js_bazel_package_runner_contract() -> int:
     return 0
 
 
+def check_flywheel_reapi_proof_contract() -> int:
+    action_path = ROOT / ".github/actions/flywheel-reapi-proof/action.yml"
+    readme_path = ROOT / "README.md"
+    roadmap_path = ROOT / "docs/roadmap.md"
+    action = action_path.read_text(encoding="utf-8")
+    readme = readme_path.read_text(encoding="utf-8")
+    roadmap = roadmap_path.read_text(encoding="utf-8")
+
+    required_action_snippets = [
+        "request_id:",
+        "-f request_id=\"${request_id}\"",
+        "--json databaseId,createdAt,displayTitle",
+        "contains($request_id)",
+        "request_id=${request_id}",
+    ]
+    forbidden_action_snippets = [
+        "sort_by(.createdAt, .databaseId) | last",
+    ]
+    required_readme_snippet = "correlated by a unique request id"
+    required_roadmap_snippets = [
+        "timestamp-only child-run resolution",
+        "concurrent consumer proofs",
+    ]
+
+    ok = True
+    for snippet in required_action_snippets:
+        if snippet not in action:
+            print(
+                f"{action_path.relative_to(ROOT)}: missing request-id correlation snippet: {snippet}",
+                file=sys.stderr,
+            )
+            ok = False
+    for snippet in forbidden_action_snippets:
+        if snippet in action:
+            print(
+                f"{action_path.relative_to(ROOT)}: stale timestamp-only correlation remains: {snippet}",
+                file=sys.stderr,
+            )
+            ok = False
+    if required_readme_snippet not in readme:
+        print(
+            f"{readme_path.relative_to(ROOT)}: missing request-id correlation docs",
+            file=sys.stderr,
+        )
+        ok = False
+    for snippet in required_roadmap_snippets:
+        if snippet not in roadmap:
+            print(
+                f"{roadmap_path.relative_to(ROOT)}: missing timestamp-only correlation warning: {snippet}",
+                file=sys.stderr,
+            )
+            ok = False
+
+    if not ok:
+        return 1
+    print("flywheel-reapi-proof request-id correlation guarded")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("check", choices=["manifest", "internal-refs", "js-bazel-runner-contract"])
+    parser.add_argument(
+        "check",
+        choices=[
+            "manifest",
+            "internal-refs",
+            "js-bazel-runner-contract",
+            "flywheel-reapi-proof-contract",
+        ],
+    )
     args = parser.parse_args()
 
     if args.check == "manifest":
         return validate_manifest()
     if args.check == "js-bazel-runner-contract":
         return check_js_bazel_package_runner_contract()
+    if args.check == "flywheel-reapi-proof-contract":
+        return check_flywheel_reapi_proof_contract()
     return check_internal_refs()
 
 


### PR DESCRIPTION
## Summary

- Generate or accept a unique `request_id` for `flywheel-reapi-proof` calls.
- Pass that id into the GloriousFlywheel proof workflow and resolve the child run by `displayTitle`, not by latest timestamp after dispatch.
- Expose the request id as a composite output and add a contract check that prevents timestamp-only correlation from returning.
- Document the concurrency safety boundary.

## Dependency

Requires tinyland-inc/GloriousFlywheel#858 to land first so `gf-reapi-cell-proof.yml` accepts `request_id` and includes it in the run name.

## Validation

- `just check`
- `just flywheel-reapi-proof-contract-check yaml-parse json-parse internal-refs-check endpoint-free-check`
- `just repo-manifest-validate js-bazel-runner-contract-check`
- `python3 -m py_compile scripts/validate-ci-templates.py`

Refs #45.
Linear: TIN-1777.