### PR TITLE
fix(secrets-scan): Docker-free TruffleHog (pinned binary) for nix runners

### DIFF
--- a/.github/actions/secrets-scan/action.yml
+++ b/.github/actions/secrets-scan/action.yml
@@ -5,6 +5,9 @@ inputs:
   trufflehog-args:
     description: "Extra args for TruffleHog"
     default: "--only-verified"
+  trufflehog-version:
+    description: "TruffleHog version (pinned binary release; no Docker)"
+    default: "3.95.3"
   gitleaks-version:
     description: "Gitleaks version"
     default: "8.21.2"
@@ -26,10 +29,22 @@ outputs:
 runs:
   using: "composite"
   steps:
+    # Docker-free: trufflesecurity/trufflehog@main is a container action and
+    # fails on Docker-less self-hosted runners (e.g. the tinyland nix compute
+    # pool: "failed to connect to the docker API at unix:///var/run/docker.sock").
+    # Install the pinned binary and scan git history directly, mirroring the
+    # gitleaks binary pattern below. `--fail` exits non-zero only when results
+    # are found; with the default `--only-verified` that means verified secrets.
+    - name: Install TruffleHog
+      shell: bash
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh \
+          | sh -s -- -b /usr/local/bin "v${{ inputs.trufflehog-version }}"
+
     - name: TruffleHog scan
-      uses: trufflesecurity/trufflehog@main
-      with:
-        extra_args: ${{ inputs.trufflehog-args }}
+      shell: bash
+      run: |
+        trufflehog --no-update git "file://${GITHUB_WORKSPACE:-$PWD}" ${{ inputs.trufflehog-args }} --fail
 
     - name: Install gitleaks
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.2.0] — 2026-06-01
+
+### Changed
+
+- **`secrets-scan` runs TruffleHog as a pinned binary, not a Docker action** —
+  `trufflesecurity/trufflehog@main` is a container action and fails on
+  Docker-less self-hosted runners ("failed to connect to the docker API at
+  unix:///var/run/docker.sock"), e.g. the tinyland nix compute pool, taking the
+  whole `secrets-scan` lane (and its downstream `needs:` jobs) red. The action
+  now installs a pinned `trufflehog` binary (new optional `trufflehog-version`
+  input, default `3.95.3`) and scans git history directly, mirroring the
+  gitleaks binary install in the same action. The gitleaks half and the
+  `findings_count` output are unchanged.
+
 ## [2.1.0] — 2026-06-01
 
 ### Changed


### PR DESCRIPTION
## Problem

The `secrets-scan` composite action's TruffleHog step used `trufflesecurity/trufflehog@main` — a **Docker container action**. On Docker-less self-hosted runners (the tinyland nix compute pool) it fails immediately:

```
failed to connect to the docker API at unix:///var/run/docker.sock; ... no such file or directory
##[error]Process completed with exit code 1.
```

That reds the whole `secrets-scan` lane and every downstream `needs: [secrets-scan]` job (lint, test) — observed on `canon-megatank-reset` PR #24 (check + test showed "skipping").

## Fix

Install the **pinned `trufflehog` binary** and scan git history directly — mirroring the gitleaks binary install already in the same action. New optional `trufflehog-version` input (default `3.95.3`). The gitleaks half and the `findings_count` output are unchanged; `--only-verified` default + `--fail` semantics preserved.

## Validation

- `just check` green locally (internal-refs resolve, gitleaks clean).
- Docker-free: no container, no daemon dependency.

Releases as **v2.2.0** (new optional input → MINOR). Also carries the already-merged, previously-unreleased js-bazel-package changes sitting on `main`.