### PR TITLE
fix(secrets-scan): install scanners to job-writable dir (nix runners)

### DIFF
--- a/.github/actions/secrets-scan/action.yml
+++ b/.github/actions/secrets-scan/action.yml
@@ -38,8 +38,14 @@ runs:
     - name: Install TruffleHog
       shell: bash
       run: |
+        # /usr/local/bin is not writable on the nix self-hosted runners, so
+        # install into a job-writable dir and export it onto PATH for the
+        # subsequent scan steps via $GITHUB_PATH.
+        BIN_DIR="${RUNNER_TEMP:-/tmp}/secrets-scan-bin"
+        mkdir -p "$BIN_DIR"
         curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh \
-          | sh -s -- -b /usr/local/bin "v${{ inputs.trufflehog-version }}"
+          | sh -s -- -b "$BIN_DIR" "v${{ inputs.trufflehog-version }}"
+        echo "$BIN_DIR" >> "$GITHUB_PATH"
 
     - name: TruffleHog scan
       shell: bash
@@ -49,8 +55,13 @@ runs:
     - name: Install gitleaks
       shell: bash
       run: |
+        # Same job-writable bin dir as TruffleHog (/usr/local/bin is not
+        # writable on the nix self-hosted runners).
+        BIN_DIR="${RUNNER_TEMP:-/tmp}/secrets-scan-bin"
+        mkdir -p "$BIN_DIR"
         curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${{ inputs.gitleaks-version }}/gitleaks_${{ inputs.gitleaks-version }}_linux_x64.tar.gz" \
-          | tar xz -C /usr/local/bin gitleaks
+          | tar xz -C "$BIN_DIR" gitleaks
+        echo "$BIN_DIR" >> "$GITHUB_PATH"
 
     - name: Resolve gitleaks config
       id: cfg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.2.1] — 2026-06-01
+
+### Fixed
+
+- **`secrets-scan` installs both scanners to a job-writable dir** — the v2.2.0
+  TruffleHog binary install (and the pre-existing gitleaks install) wrote to
+  `/usr/local/bin`, which is not writable by the runner user on the nix
+  self-hosted pool (`install: cannot create regular file ...: Permission
+  denied`). Both now install into `$RUNNER_TEMP/secrets-scan-bin` and prepend
+  it to `$GITHUB_PATH`. The gitleaks write was latently broken on these runners
+  too — it just never ran because the Docker-based TruffleHog step failed first.
+
 ## [2.2.0] — 2026-06-01
 
 ### Changed


### PR DESCRIPTION
Follow-up to #49 / v2.2.0. The trufflehog binary install (and the pre-existing gitleaks install) wrote to `/usr/local/bin`, which is **not writable** by the runner user on the nix self-hosted pool:

```
install: cannot create regular file '/usr/local/bin/trufflehog': Permission denied
```

The gitleaks write had the same latent bug — it just never executed because the old Docker trufflehog step died first. Both scanners now install into `$RUNNER_TEMP/secrets-scan-bin` and prepend it to `$GITHUB_PATH`. Verified on canon-megatank-reset PR #24. Releases as **v2.2.1**.