### PR TITLE
feat(js-bazel-package): opt-in default-off cache-backed Bazel lane (TIN-2110)

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -88,6 +88,17 @@ on:
         description: "Bazel validation attempts for transient external archive fetch failures"
         type: string
         default: "3"
+      cache_backed:
+        description: >-
+          Opt-in (default false) shared-cache-backed Bazel validation. When true,
+          the Bazel target validation runs through the cache-attachment contract
+          (fail-closed) and `--config=ci-cached --remote_cache=$BAZEL_REMOTE_CACHE
+          --remote_upload_local_results=false`, reading the shared Bazel cache.
+          CACHE-FIRST only: no remote executor is wired. When false/unset the
+          existing plain `bazelisk build ... --verbose_failures` path runs
+          byte-identically (zero behavior change for non-opted consumers).
+        type: boolean
+        default: false
       package_dir:
         description: "Directory containing the Bazel-built publishable package"
         type: string
@@ -638,6 +649,7 @@ jobs:
           run_with_bazel_fetch_retry "Validate package surface" "$COMMAND"
 
       - name: Validate Bazel targets
+        if: ${{ !inputs.cache_backed }}
         shell: bash
         env:
           BAZEL_TARGETS: ${{ inputs.bazel_targets || '//:pkg' }}
@@ -651,6 +663,54 @@ jobs:
           source "$BAZEL_FETCH_RETRY_HELPER"
           targets_quoted="$(printf '%q ' "${bazel_targets[@]}")"
           run_with_bazel_fetch_retry "Validate Bazel targets" "npx --yes @bazel/bazelisk build ${targets_quoted}--verbose_failures"
+
+      # Opt-in (cache_backed=true) shared-cache-backed validation. This is a NEW
+      # conditional path; the default path above is untouched. CACHE-FIRST only:
+      # no remote executor is ever wired here (TIN-1997 Option D / TIN-2110).
+      - name: Assert shared-cache attachment (cache-backed lane)
+        if: ${{ inputs.cache_backed }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The contract script ships in this ci-templates repo; locate it from
+          # the checked-out caller workspace fallback, else fetch the pinned copy.
+          script="$RUNNER_TEMP/cache-attachment-contract.sh"
+          if [ -f "$WORKSPACE_DIR/scripts/cache-attachment-contract.sh" ]; then
+            script="$WORKSPACE_DIR/scripts/cache-attachment-contract.sh"
+          else
+            curl -fsSL \
+              "https://raw.githubusercontent.com/tinyland-inc/ci-templates/${CI_TEMPLATES_REF}/scripts/cache-attachment-contract.sh" \
+              -o "$script"
+            chmod +x "$script"
+          fi
+          export GF_BAZEL_SUBSTRATE_MODE="${GF_BAZEL_SUBSTRATE_MODE:-shared-cache-backed}"
+          bash "$script" --strict
+        env:
+          CI_TEMPLATES_REF: v2
+
+      - name: Validate Bazel targets (cache-backed)
+        if: ${{ inputs.cache_backed }}
+        shell: bash
+        env:
+          BAZEL_TARGETS: ${{ inputs.bazel_targets || '//:pkg' }}
+        run: |
+          set -euo pipefail
+          cd "$WORKSPACE_DIR"
+          if [ -z "${BAZEL_REMOTE_CACHE:-}" ]; then
+            echo "::error::cache_backed=true but BAZEL_REMOTE_CACHE is unset. On self-hosted cluster runners nix-setup exports it from cluster DNS; otherwise supply it via repo/org secret or input. The cache-backed lane fails closed rather than silently building local-only."
+            exit 1
+          fi
+          # shellcheck disable=SC2153
+          read -r -a bazel_targets <<< "$BAZEL_TARGETS"
+
+          # shellcheck source=/dev/null
+          source "$BAZEL_FETCH_RETRY_HELPER"
+          targets_quoted="$(printf '%q ' "${bazel_targets[@]}")"
+          # CACHE-FIRST: ci-cached config + injected remote cache, read-only
+          # (no upload), and no remote executor is wired. The remote cache
+          # hit/transfer lines in this step's log are the real-attach proof.
+          run_with_bazel_fetch_retry "Validate Bazel targets (cache-backed)" \
+            "npx --yes @bazel/bazelisk build ${targets_quoted}--config=ci-cached --remote_cache=${BAZEL_REMOTE_CACHE} --remote_upload_local_results=false --verbose_failures"
 
       - name: Validate npm tarball from Bazel artifact
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# AGENTS.md — tinyland-inc/ci-templates
+
+Operator/agent guide for the shared Tinyland CI surface. This repo is a
+**reusable** GitHub Actions library consumed by ~190 repos. Treat every change as
+a fleet-wide change.
+
+## What this repo is
+
+- Reusable **workflows** (`.github/workflows/*.yml` with `workflow_call`) and
+  composite **actions** (`.github/actions/*/action.yml`) that spokes pin and
+  consume. It is not an application; nothing here deploys.
+- The contract spokes conform to lives in
+  `tinyland-inc/site.scaffold/docs/CI-SCHEMA.md`. This repo vendors schemas at
+  stable paths under `schemas/`.
+
+## Golden rules
+
+1. **Pin, don't float.** Consumers pin `@v2.x` (immutable) or the floating major
+   `@v2`. Internal composite-to-composite refs use the floating major (`@v2`),
+   never `@main` (enforced by `scripts/validate-ci-templates.py internal-refs`).
+2. **Default-off, opt-in changes only.** A new behavior added to a shared
+   workflow MUST be gated behind a new input that defaults to the pre-existing
+   behavior. Non-opted consumers must be byte-identical. Prove it by diffing the
+   default execution path.
+3. **No baked endpoints, credentials, or upload authority** in `bazelrc/*.bazelrc`
+   (enforced by `just endpoint-free-check` + `just ci-cached-endpoint-free-check`).
+   Cache/executor endpoints are runtime authority, supplied as flags by the
+   composite/workflow from validated env.
+4. **Amend `CHANGELOG.md` `## [Unreleased]`** in every PR (gated by `release.yml`).
+5. **Run `just check` before pushing** (or `nix develop --command just check`).
+
+## Local validation
+
+```bash
+just check                       # full suite
+nix develop --command just check # if tools are not on PATH
+```
+
+`just check` parses all workflow/action YAML + JSON schemas, validates
+`tinyland.repo.json`, asserts internal action refs resolve, guards the
+js-bazel-package runner + cache-backed contracts, asserts the bazelrc fragments
+stay endpoint-free, and runs the gitleaks working-tree scan.
+
+## Bazel cache enrollment (cache-first, TIN-1997 Option D / TIN-2110)
+
+The `js-bazel-package.yml` workflow has an **opt-in, default-off** cache-backed
+Bazel validation lane. It is the canonical template for fanning shared-cache
+enrollment out to spokes.
+
+- **Doctrine: cache-first only.** This lane reads/writes the shared Bazel cache.
+  It does NOT wire a remote executor / REAPI. Remote execution is out of scope;
+  the `flywheel-bazel` composite + `flywheel-reapi-proof` cover executor lanes
+  separately.
+- **Enroll** by setting `cache_backed: true` on the `js-bazel-package.yml`
+  consumer call. When unset, the existing plain
+  `bazelisk build … --verbose_failures` path runs byte-identically.
+- **Endpoints are never baked.** `bazelrc/ci-cached.bazelrc` defines endpoint-free
+  `:ci-cached` behavior; the workflow injects `--remote_cache=$BAZEL_REMOTE_CACHE`
+  after the fail-closed `scripts/cache-attachment-contract.sh --strict` gate.
+  On self-hosted Tinyland cluster runners, `nix-setup` exports
+  `BAZEL_REMOTE_CACHE` from cluster DNS — no new secret or infra required.
+- **Do NOT** create per-repo runners, bespoke cache instances, localhost/
+  port-forward endpoints baked into config, or static long-lived cache secrets.
+  Route everything through this shared surface + the GloriousFlywheel substrate.
+- **Real attach, not nominal.** Enrollment counts only when the build log shows
+  remote cache hit/transfer lines. A green build on a `tinyland-nix` runner with
+  only `--disk_cache` is NOT enrollment and must be reported as such.
+- **Self-verify** locally with `scripts/cache-attachment-contract.sh --strict`
+  (classifies `compatibility-local-only` / `shared-cache-backed` /
+  `executor-backed`; rejects unexpanded `${…}` placeholders, non-`grpc`/`http`
+  endpoints, and localhost without `GF_BAZEL_ALLOW_LOCALHOST_PROOF=true`).
+
+See `docs/js-bazel-package.md` (`cache_backed`) for the consumer-facing details.
+
+## Releasing
+
+See `RELEASING.md`. On a `release: vX.Y.Z` commit to `main`, `release.yml` cuts
+the immutable tag and moves the floating major. Never reuse or force a tag
+out-of-band.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`js-bazel-package.yml` opt-in `cache_backed` shared-cache lane (TIN-2110)** —
+  a new boolean input (default `false`). When `true`, Bazel target validation
+  runs a fail-closed cache-attachment contract step and then
+  `--config=ci-cached --remote_cache=$BAZEL_REMOTE_CACHE
+  --remote_upload_local_results=false`, reading the shared Bazel cache
+  (cache-first, TIN-1997 Option D / GF#889). When `false`/unset the existing
+  `bazelisk build … --verbose_failures` path runs **byte-identically** — zero
+  behavior change for the ~190 non-opted consumers. The lane is cache-first only
+  and never wires a remote executor.
+- **`scripts/cache-attachment-contract.sh`** — shared fail-closed classifier
+  generalized from MassageIthaca, aligned to TIN-2108 naming
+  (`GF_BAZEL_SUBSTRATE_MODE`; modes `compatibility-local-only` /
+  `shared-cache-backed` / `executor-backed`). Rejects unexpanded `${...}`
+  placeholders, non-`grpc`/`http` endpoints, localhost without explicit proof,
+  executor-without-cache, and executor≠cache mismatches.
+- **`bazelrc/ci-cached.bazelrc`** — endpoint-free `--config=ci-cached`,
+  `cache-readonly`, and `no-remote-cache` behavior for consumer `.bazelrc`
+  files; read-only by default and never executor-selecting.
+- **`AGENTS.md`** — agent/operator guide documenting the shared-surface golden
+  rules and the cache-first Bazel enrollment doctrine (closes the missing-AGENTS
+  AX gap).
+- **`just ci-cached-endpoint-free-check` + `just cache-backed-optin-contract-check`**
+  — repo-local guards asserting `bazelrc/ci-cached.bazelrc` stays endpoint-free
+  and the `cache_backed` lane stays default-off and cache-first (no executor
+  wiring in the workflow).
+
 ## [2.2.1] — 2026-06-01
 
 ### Fixed

--- a/Justfile
+++ b/Justfile
@@ -9,7 +9,7 @@ _default:
     @just --list --unsorted
 
 # Run all repository-local validation.
-check: yaml-parse json-parse repo-manifest-validate internal-refs-check js-bazel-runner-contract-check flywheel-reapi-proof-contract-check endpoint-free-check secrets-scan-dir
+check: yaml-parse json-parse repo-manifest-validate internal-refs-check js-bazel-runner-contract-check flywheel-reapi-proof-contract-check endpoint-free-check ci-cached-endpoint-free-check cache-backed-optin-contract-check secrets-scan-dir
     @echo "ci-templates checks passed."
 
 # Parse all GitHub workflow/action YAML with Ruby's stdlib YAML parser.
@@ -47,6 +47,18 @@ flywheel-reapi-proof-contract-check:
 endpoint-free-check:
     cd {{ root }} && ! grep -Eq -- '--remote_cache=|--remote_executor=|--remote_upload_local_results=true|grpc://bazel-cache|grpc://gf-reapi-cell' bazelrc/flywheel.bazelrc
     @echo "flywheel.bazelrc endpoint-free"
+
+# Ensure the ci-cached bazelrc fragment has no baked endpoints or upload authority.
+# `--remote_cache=` with an empty value (the no-remote-cache disable knob) is the
+# only permitted occurrence; any non-empty endpoint or executor is rejected.
+ci-cached-endpoint-free-check:
+    cd {{ root }} && ! grep -Eq -- '--remote_cache=[^[:space:]]|--remote_executor=|--remote_upload_local_results=true|grpc://bazel-cache|grpc://gf-reapi-cell|grpcs?://[a-z0-9.-]+:[0-9]' bazelrc/ci-cached.bazelrc
+    @echo "ci-cached.bazelrc endpoint-free"
+
+# Ensure the cache-backed opt-in stays opt-in/default-off and cache-first
+# (no remote executor wired in the workflow's cache-backed path).
+cache-backed-optin-contract-check:
+    cd {{ root }} && python3 scripts/validate-ci-templates.py cache-backed-optin-contract
 
 # Scan current files for secrets.
 secrets-scan-dir:

--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ nix develop --command just check
 
 The check parses all workflow/action YAML, parses vendored JSON schemas,
 validates `tinyland.repo.json`, verifies v2 internal action refs resolve to
-checked-in sibling actions, asserts `bazelrc/flywheel.bazelrc` remains
-endpoint-free, and runs the canonical Tinyland gitleaks working-tree scan.
+checked-in sibling actions, asserts `bazelrc/flywheel.bazelrc` and
+`bazelrc/ci-cached.bazelrc` remain endpoint-free, asserts the `cache_backed`
+opt-in lane stays default-off and cache-first, and runs the canonical Tinyland
+gitleaks working-tree scan.
 
 ## Composite actions
 
@@ -119,7 +121,7 @@ See per-action `action.yml` files for full input/output documentation.
 
 | Workflow | Purpose |
 |---|---|
-| `js-bazel-package.yml` | Pre-existing: JS/TS packages built by Bazel and published to GitHub Packages, with npmjs required/optional/disabled by package policy. |
+| `js-bazel-package.yml` | Pre-existing: JS/TS packages built by Bazel and published to GitHub Packages, with npmjs required/optional/disabled by package policy. Supports an **opt-in, default-off `cache_backed`** shared-cache Bazel validation lane (cache-first; see below). |
 | `npm-publish.yml` | Pre-existing: hosted-only Node package build + publish. |
 | **`spoke-ci.yml`** | Canonical spoke CI: secrets-scan, lanes-load, per-lane flywheel-bazel build/test, bazel-graph, optional Playwright. |
 | **`spoke-lane-env.yml`** | Canonical PR-env workflow. Replaces hand-rolled `pr-env-lanes.yml`. |
@@ -136,7 +138,7 @@ are vendored from `tinyland-inc/site.scaffold/docs/schemas/`. The
 schema-doc repo is the source of truth; this repo vendors at known
 stable paths so composite actions can `jsonschema` against them.
 
-## Bazelrc fragment
+## Bazelrc fragments
 
 `bazelrc/flywheel.bazelrc` is endpoint-free. It defines safe behavior for
 `--config=flywheel` and `--config=flywheel-executor`, but does not hard-code
@@ -145,6 +147,30 @@ The `flywheel-bazel` composite installs it at runtime and supplies
 `--remote_cache` from `BAZEL_REMOTE_CACHE`; executor mode additionally requires
 `BAZEL_REMOTE_EXECUTOR`. Pull requests default to read-only cache use unless a
 trusted lane sets `GF_BAZEL_REMOTE_UPLOAD=true`.
+
+`bazelrc/ci-cached.bazelrc` is the consumer-naming counterpart for the
+**cache-first** lane. It defines endpoint-free `--config=ci-cached`,
+`--config=cache-readonly`, and `--config=no-remote-cache` behavior that spoke
+`.bazelrc` files reference. It is read-only by default (no upload) and never
+selects a remote executor. `scripts/cache-attachment-contract.sh` is the
+fail-closed checker that gates cache-backed work (`--strict` requires a real
+`BAZEL_REMOTE_CACHE`; rejects unexpanded `${...}` placeholders, non-`grpc`/`http`
+endpoints, and localhost without explicit proof).
+
+## Cache-backed enrollment (cache-first, TIN-2110)
+
+`js-bazel-package.yml` exposes an **opt-in, default-off** `cache_backed` input.
+When unset, the Bazel validation runs the existing
+`bazelisk build … --verbose_failures` path byte-identically — zero impact on
+non-opted consumers. When `cache_backed: true`, the workflow runs the fail-closed
+cache-attachment contract and then validates with
+`--config=ci-cached --remote_cache=$BAZEL_REMOTE_CACHE
+--remote_upload_local_results=false`, reading the shared Bazel cache. This lane is
+cache-first only (TIN-1997 Option D / GF#889); it never wires a remote executor.
+On self-hosted Tinyland cluster runners, `nix-setup` exports `BAZEL_REMOTE_CACHE`
+from cluster DNS, so attach needs no new secret or infrastructure. See
+[`docs/js-bazel-package.md`](docs/js-bazel-package.md) (`cache_backed`) and
+[`AGENTS.md`](AGENTS.md) for the enrollment doctrine.
 
 ## Contributing
 

--- a/bazelrc/ci-cached.bazelrc
+++ b/bazelrc/ci-cached.bazelrc
@@ -1,0 +1,42 @@
+# ci-cached.bazelrc - endpoint-free shared-cache behavior for the cache-backed lane.
+#
+# Vendored by tinyland-inc/ci-templates. This is the consumer-naming counterpart
+# of bazelrc/flywheel.bazelrc: it defines the `ci-cached` config families that
+# spoke .bazelrc files reference, while the cache endpoint stays runtime
+# authority. The cache-backed path in js-bazel-package.yml (cache_backed=true)
+# validates BAZEL_REMOTE_CACHE via scripts/cache-attachment-contract.sh and then
+# supplies the remote cache endpoint as a runtime Bazel flag.
+#
+# Do not put deployment-specific endpoints, credentials, auth headers, or cache
+# upload authority in this file.
+#
+# Hard invariants:
+#   - Cache hits are not RBE. This fragment is CACHE-FIRST (TIN-1997 Option D);
+#     it never selects a remote executor.
+#   - read-only by default: clients read the shared cache, never upload local
+#     results (TIN-1462 posture). A trusted lane may opt into uploads by
+#     overriding the upload-local-results flag to true at invocation.
+#
+# A consumer .bazelrc is expected to define a base `:ci` config that, at minimum,
+# empties the disk cache in CI so a green build proves the REMOTE cache rather
+# than an incidental local disk hit:
+#
+#   build:ci --disk_cache=
+#
+# The `ci-cached` block then layers shared-cache behavior on top of it.
+
+# Shared remote cache behavior. The workflow/wrapper supplies --remote_cache and
+# upload policy after validating BAZEL_REMOTE_CACHE.
+build:ci-cached --config=ci
+build:ci-cached --remote_upload_local_results=false
+build:ci-cached --remote_download_minimal
+build:ci-cached --remote_timeout=60
+
+# Explicit read-only and disable knobs for proof/debug lanes.
+build:cache-readonly --remote_upload_local_results=false
+build:no-remote-cache --remote_cache=
+
+# Executor-backed is CLASSIFIED for naming convergence with the GF REAPI cell
+# lane but is NOT selected by the cache-first lane. The cache-backed path in
+# ci-templates never passes --config=executor-backed or --remote_executor.
+build:executor-backed --config=ci-cached

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -118,6 +118,47 @@ Meaning:
   - use this for Bazel-first packages whose release authority is GitHub
     tag/release, GitHub Packages, and the Tinyland Bazel registry
 
+### `cache_backed`
+
+Opt-in (default `false`) shared-cache-backed Bazel validation. This is the
+TIN-2110 cache-first enrollment surface (TIN-1997 Option D, proven by GF#889).
+
+- `false` / unset (default)
+  - the Bazel target validation runs the existing plain
+    `npx --yes @bazel/bazelisk build <targets> --verbose_failures` path,
+    byte-identically. Non-opted consumers see zero behavior change.
+- `true`
+  - a fail-closed cache-attachment contract step runs first
+    (`scripts/cache-attachment-contract.sh --strict`), rejecting unexpanded
+    `${...}` placeholders, non-`grpc`/`http` endpoints, and localhost endpoints
+    (unless `GF_BAZEL_ALLOW_LOCALHOST_PROOF=true`)
+  - the Bazel validation then runs
+    `--config=ci-cached --remote_cache=$BAZEL_REMOTE_CACHE
+    --remote_upload_local_results=false`, reading the shared Bazel cache
+  - the lane fails closed when `BAZEL_REMOTE_CACHE` is unset rather than
+    silently building local-only
+
+`cache_backed` is **cache-first only**. It never wires a remote executor; REAPI /
+remote execution is out of scope for this lane. On self-hosted Tinyland cluster
+runners, `nix-setup` exports `BAZEL_REMOTE_CACHE` from cluster DNS, so attach
+needs no new secret or infrastructure; off-cluster, supply the endpoint via a
+repo/org secret or a wrapping step before validation.
+
+Consumers opting in must:
+
+1. set `cache_backed: true` in the `with:` block
+2. vendor `bazelrc/ci-cached.bazelrc` behavior in their `.bazelrc` (a base `:ci`
+   config that empties `--disk_cache=` in CI plus the `:ci-cached` block) so a
+   green build proves the **remote** cache, not an incidental disk hit
+3. optionally vendor `scripts/cache-attachment-contract.sh` for the same
+   fail-closed self-check locally (`scripts/cache-attachment-contract.sh
+   --strict`); the workflow falls back to fetching the pinned ci-templates copy
+   when the consumer has not vendored it
+
+Real enrollment is proven by remote cache hit/transfer lines in the cache-backed
+validation step log. A green build that shows only `--disk_cache` and no remote
+transfer is **not** enrollment.
+
 ### `github_package_name`
 
 `github_package_name` is the package coordinate used only for the GitHub

--- a/scripts/cache-attachment-contract.sh
+++ b/scripts/cache-attachment-contract.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Classify the current Bazel cache/executor attachment without running Bazel.
+#
+# Generalized from MassageIthaca/scripts/cache-attachment-contract.sh (the merged,
+# GF#889-proven shape) into a shared ci-templates entrypoint so any spoke can
+# fail closed before a cache-backed Bazel invocation.
+#
+# Naming aligns with the TIN-2108 in-flight scripts (GF_BAZEL_SUBSTRATE_MODE;
+# modes compatibility-local-only / shared-cache-backed / executor-backed) for
+# easy convergence, while the fail-closed endpoint validation mirrors the proven
+# MI logic verbatim.
+#
+# Classification:
+#   BAZEL_REMOTE_EXECUTOR set  => executor-backed   (out of scope this lane; classified, never selected)
+#   else BAZEL_REMOTE_CACHE set => shared-cache-backed
+#   else                        => compatibility-local-only
+#
+# Fail-closed (exit 1) when:
+#   - either endpoint contains a literal ${...} placeholder (unexpanded secret/var)
+#   - either endpoint does not start with grpc://, grpcs://, http://, or https://
+#   - localhost/127.0.0.1/::1 endpoint without GF_BAZEL_ALLOW_LOCALHOST_PROOF=true
+#   - executor set without a cache endpoint
+#   - executor != cache unless GF_BAZEL_ALLOW_SEPARATE_EXECUTOR_CACHE=true
+#   - declared GF_BAZEL_SUBSTRATE_MODE disagreeing with endpoint presence
+#   - --strict with an empty BAZEL_REMOTE_CACHE
+
+set -euo pipefail
+
+STRICT=false
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/cache-attachment-contract.sh [--strict]
+
+Without --strict this reports whether the current shell is
+compatibility-local-only, shared-cache-backed, or executor-backed. With --strict
+it requires a real BAZEL_REMOTE_CACHE endpoint before cache-backed Bazel work
+may run (the fail-closed gate for the cache-backed lane).
+
+Environment:
+  BAZEL_REMOTE_CACHE        Shared Bazel remote cache endpoint (grpc/grpcs/http/https).
+  BAZEL_REMOTE_EXECUTOR     Optional remote executor endpoint. Classified as
+                            executor-backed but NOT selected by the cache-first lane.
+  GF_BAZEL_SUBSTRATE_MODE   Optional declared mode; must agree with endpoint presence.
+  GF_BAZEL_ALLOW_LOCALHOST_PROOF
+                            Set true to permit a localhost endpoint (explicit proof only).
+  GF_BAZEL_ALLOW_SEPARATE_EXECUTOR_CACHE
+                            Set true to permit executor != cache (default: GF REAPI cell
+                            uses one endpoint for both).
+EOF
+}
+
+for arg in "$@"; do
+  case "${arg}" in
+  --strict)
+    STRICT=true
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+  esac
+done
+
+remote_cache="${BAZEL_REMOTE_CACHE:-}"
+remote_executor="${BAZEL_REMOTE_EXECUTOR:-}"
+mode="${GF_BAZEL_SUBSTRATE_MODE:-}"
+
+if [[ -n ${remote_executor} ]]; then
+  expected_mode="executor-backed"
+elif [[ -n ${remote_cache} ]]; then
+  expected_mode="shared-cache-backed"
+else
+  expected_mode="compatibility-local-only"
+fi
+
+if [[ -z ${mode} ]]; then
+  effective_mode="${expected_mode}"
+else
+  effective_mode="${mode}"
+fi
+
+context="developer-machine"
+if [[ ${GITHUB_ACTIONS:-} == "true" ]]; then
+  context="github-actions"
+elif [[ -n ${CI:-} ]]; then
+  context="ci"
+fi
+
+literal_cache=false
+if [[ ${remote_cache} == *'${'* ]] || [[ ${remote_cache} == *'}'* ]]; then
+  literal_cache=true
+fi
+
+literal_executor=false
+if [[ ${remote_executor} == *'${'* ]] || [[ ${remote_executor} == *'}'* ]]; then
+  literal_executor=true
+fi
+
+unsupported_cache=false
+if [[ -n ${remote_cache} ]] && [[ ! ${remote_cache} =~ ^(grpc|grpcs|http|https):// ]]; then
+  unsupported_cache=true
+fi
+
+unsupported_executor=false
+if [[ -n ${remote_executor} ]] && [[ ! ${remote_executor} =~ ^(grpc|grpcs|http|https):// ]]; then
+  unsupported_executor=true
+fi
+
+endpoint_is_localhost() {
+  local endpoint="$1"
+  local host
+  host="${endpoint#*://}"
+  host="${host%%/*}"
+  host="${host%%:*}"
+  host="${host#[}"
+  host="${host%]}"
+  case "${host}" in
+  localhost | 127.0.0.1 | ::1 | 0.0.0.0) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+allow_localhost="${GF_BAZEL_ALLOW_LOCALHOST_PROOF:-false}"
+localhost_cache=false
+if [[ -n ${remote_cache} ]] && endpoint_is_localhost "${remote_cache}"; then
+  localhost_cache=true
+fi
+localhost_executor=false
+if [[ -n ${remote_executor} ]] && endpoint_is_localhost "${remote_executor}"; then
+  localhost_executor=true
+fi
+
+cat <<EOF
+Bazel Cache Attachment
+======================
+Context:            ${context}
+Bazel mode:         ${effective_mode}
+Bazel remote cache: ${remote_cache:-unset}
+Bazel executor:     ${remote_executor:-unset}
+Expected mode:      ${expected_mode}
+Strict:             ${STRICT}
+
+Contract:
+- cache-backed work gets its endpoint from BAZEL_REMOTE_CACHE
+- executor-backed work gets BAZEL_REMOTE_EXECUTOR and uses BAZEL_REMOTE_CACHE
+  as the CAS/action-cache authority; current GF lanes use the REAPI cell for both
+  (executor-backed is classified here but NOT selected by the cache-first lane)
+- the consumer .bazelrc keeps cache/executor endpoints out of checked-in defaults
+- empty BAZEL_REMOTE_CACHE means compatibility-local-only; cache-backed
+  entrypoints refuse it
+EOF
+
+if [[ ${effective_mode} != "${expected_mode}" ]]; then
+  echo
+  echo "ERROR: GF_BAZEL_SUBSTRATE_MODE=${effective_mode} disagrees with endpoint presence (expected ${expected_mode})."
+  exit 1
+fi
+
+if [[ ${literal_cache} == "true" ]]; then
+  echo
+  echo "ERROR: BAZEL_REMOTE_CACHE is a literal shell placeholder, not a real endpoint."
+  exit 1
+fi
+
+if [[ ${literal_executor} == "true" ]]; then
+  echo
+  echo "ERROR: BAZEL_REMOTE_EXECUTOR is a literal shell placeholder, not a real endpoint."
+  exit 1
+fi
+
+if [[ ${unsupported_cache} == "true" ]]; then
+  echo
+  echo "ERROR: BAZEL_REMOTE_CACHE must start with grpc://, grpcs://, http://, or https://."
+  exit 1
+fi
+
+if [[ ${unsupported_executor} == "true" ]]; then
+  echo
+  echo "ERROR: BAZEL_REMOTE_EXECUTOR must start with grpc://, grpcs://, http://, or https://."
+  exit 1
+fi
+
+if [[ ${localhost_cache} == "true" && ${allow_localhost} != "true" ]]; then
+  echo
+  echo "ERROR: BAZEL_REMOTE_CACHE points at localhost. Set GF_BAZEL_ALLOW_LOCALHOST_PROOF=true only with explicit proof; the shared lane expects the cluster cache endpoint."
+  exit 1
+fi
+
+if [[ ${localhost_executor} == "true" && ${allow_localhost} != "true" ]]; then
+  echo
+  echo "ERROR: BAZEL_REMOTE_EXECUTOR points at localhost. Set GF_BAZEL_ALLOW_LOCALHOST_PROOF=true only with explicit proof."
+  exit 1
+fi
+
+if [[ -n ${remote_executor} && -z ${remote_cache} ]]; then
+  echo
+  echo "ERROR: executor-backed mode requires BAZEL_REMOTE_CACHE."
+  exit 1
+fi
+
+if [[ -n ${remote_executor} && -n ${remote_cache} &&
+  ${remote_cache} != "${remote_executor}" &&
+  ${GF_BAZEL_ALLOW_SEPARATE_EXECUTOR_CACHE:-false} != "true" ]]; then
+  echo
+  echo "ERROR: executor-backed mode requires BAZEL_REMOTE_CACHE to match BAZEL_REMOTE_EXECUTOR for the GloriousFlywheel REAPI cell."
+  exit 1
+fi
+
+if [[ ${STRICT} == "true" && -z ${remote_cache} ]]; then
+  echo
+  echo "ERROR: strict mode requires BAZEL_REMOTE_CACHE to be set."
+  exit 1
+fi
+
+echo
+echo "Status: ${expected_mode}"

--- a/scripts/validate-ci-templates.py
+++ b/scripts/validate-ci-templates.py
@@ -175,6 +175,90 @@ def check_flywheel_reapi_proof_contract() -> int:
     return 0
 
 
+def check_cache_backed_optin_contract() -> int:
+    """Guard the TIN-2110 opt-in cache-backed lane: default-off and cache-first.
+
+    Asserts the new `cache_backed` input is default-off, the default Bazel
+    validation step stays guarded so non-opted consumers are byte-identical, the
+    cache-backed step routes through `--config=ci-cached` + injected
+    `--remote_cache`, gates on the cache-attachment contract, and NEVER wires a
+    remote executor (cache-first only, TIN-1997 Option D).
+    """
+    workflow_path = ROOT / ".github/workflows/js-bazel-package.yml"
+    docs_path = ROOT / "docs/js-bazel-package.md"
+    bazelrc_path = ROOT / "bazelrc/ci-cached.bazelrc"
+    contract_path = ROOT / "scripts/cache-attachment-contract.sh"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    docs = docs_path.read_text(encoding="utf-8")
+
+    ok = True
+
+    if not contract_path.exists():
+        print(f"missing {contract_path.relative_to(ROOT)}", file=sys.stderr)
+        ok = False
+    if not bazelrc_path.exists():
+        print(f"missing {bazelrc_path.relative_to(ROOT)}", file=sys.stderr)
+        ok = False
+
+    # Input is declared and default-off.
+    if not re.search(r"\n      cache_backed:\n", workflow):
+        print(f"{workflow_path.relative_to(ROOT)}: missing cache_backed input", file=sys.stderr)
+        ok = False
+    cache_backed_block = re.search(
+        r"\n      cache_backed:\n(?:.*\n)*?        default: (\w+)\n", workflow
+    )
+    if not cache_backed_block or cache_backed_block.group(1) != "false":
+        print(
+            f"{workflow_path.relative_to(ROOT)}: cache_backed must declare default: false",
+            file=sys.stderr,
+        )
+        ok = False
+
+    required_workflow_snippets = [
+        # default path stays guarded => byte-identical for non-opted consumers
+        "if: ${{ !inputs.cache_backed }}",
+        # opt-in path gated on the fail-closed cache-attachment contract
+        "Assert shared-cache attachment (cache-backed lane)",
+        "cache-attachment-contract.sh",
+        "--strict",
+        # opt-in path is cache-first: ci-cached config + injected remote cache, no upload
+        "--config=ci-cached",
+        "--remote_cache=${BAZEL_REMOTE_CACHE}",
+        "--remote_upload_local_results=false",
+        # the unchanged default command must still be present verbatim
+        'run_with_bazel_fetch_retry "Validate Bazel targets" '
+        '"npx --yes @bazel/bazelisk build ${targets_quoted}--verbose_failures"',
+    ]
+    for snippet in required_workflow_snippets:
+        if snippet not in workflow:
+            print(
+                f"{workflow_path.relative_to(ROOT)}: missing cache-backed snippet: {snippet}",
+                file=sys.stderr,
+            )
+            ok = False
+
+    # CACHE-FIRST: the workflow must never wire a remote executor anywhere.
+    for forbidden in ("--remote_executor", "--config=executor-backed", "BAZEL_REMOTE_EXECUTOR"):
+        if forbidden in workflow:
+            print(
+                f"{workflow_path.relative_to(ROOT)}: cache-first lane must not wire executor: {forbidden}",
+                file=sys.stderr,
+            )
+            ok = False
+
+    if "cache-backed" not in docs.lower() and "cache_backed" not in docs:
+        print(
+            f"{docs_path.relative_to(ROOT)}: missing cache-backed lane documentation",
+            file=sys.stderr,
+        )
+        ok = False
+
+    if not ok:
+        return 1
+    print("cache-backed opt-in lane is default-off and cache-first")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -184,6 +268,7 @@ def main() -> int:
             "internal-refs",
             "js-bazel-runner-contract",
             "flywheel-reapi-proof-contract",
+            "cache-backed-optin-contract",
         ],
     )
     args = parser.parse_args()
@@ -194,6 +279,8 @@ def main() -> int:
         return check_js_bazel_package_runner_contract()
     if args.check == "flywheel-reapi-proof-contract":
         return check_flywheel_reapi_proof_contract()
+    if args.check == "cache-backed-optin-contract":
+        return check_cache_backed_optin_contract()
     return check_internal_refs()
 
 


### PR DESCRIPTION
## Summary

Adds an **opt-in, default-off** shared-cache-backed Bazel validation lane to the shared `js-bazel-package.yml` reusable workflow (consumed by ~190 repos). This is the TIN-2110 cache-first pilot (TIN-1997 Option D), the reusable template for fanning shared-cache enrollment out to spokes.

- New boolean input `cache_backed` (**default `false`**).
- **`false`/unset (default):** the existing `npx --yes @bazel/bazelisk build <targets> --verbose_failures` validation runs **byte-identically** — **zero impact on non-opted consumers**. The only delta to the default step is a single `if: ${{ !inputs.cache_backed }}` guard that evaluates true by default; the executed command is unchanged.
- **`true`:** a fail-closed cache-attachment contract step runs first (`scripts/cache-attachment-contract.sh --strict`), then validation runs `--config=ci-cached --remote_cache=$BAZEL_REMOTE_CACHE --remote_upload_local_results=false`, **reading the shared Bazel cache**.

## Cache-only (no executor / REAPI)

This lane is **cache-first only**. It never wires `--remote_executor`, `--config=executor-backed`, or `BAZEL_REMOTE_EXECUTOR`. Remote execution / REAPI is explicitly out of scope (covered separately by `flywheel-bazel` / `flywheel-reapi-proof`). A repo-local guard (`just cache-backed-optin-contract-check`) asserts the workflow's cache-backed path never wires an executor.

## What's added

- **`scripts/cache-attachment-contract.sh`** — shared fail-closed classifier generalized from MassageIthaca's proven (GF#889) shape, with naming aligned to the TIN-2108 in-flight scripts (`GF_BAZEL_SUBSTRATE_MODE`; modes `compatibility-local-only` / `shared-cache-backed` / `executor-backed`). Rejects unexpanded `${...}` placeholders, non-`grpc`/`http` endpoints, localhost without `GF_BAZEL_ALLOW_LOCALHOST_PROOF=true`, executor-without-cache, and executor≠cache mismatches.
- **`bazelrc/ci-cached.bazelrc`** — endpoint-free `ci-cached` / `cache-readonly` / `no-remote-cache` config families for consumer `.bazelrc` files; read-only by default; never executor-selecting. Endpoints stay runtime authority (injected as flags).
- **`AGENTS.md`** — agent/operator guide for the shared surface + cache-first enrollment doctrine (closes the missing-AGENTS AX gap the recon flagged).
- **`just ci-cached-endpoint-free-check` + `just cache-backed-optin-contract-check`** — repo-local guards (default-off + cache-first + endpoint-free invariants).
- README + `docs/js-bazel-package.md` document the `cache_backed` lane.

## Endpoint injection / no new infra

Endpoints are never baked. On self-hosted Tinyland cluster runners, `nix-setup` already exports `BAZEL_REMOTE_CACHE` from cluster DNS (`grpc://bazel-cache.nix-cache.svc.cluster.local:9092`), so attach needs **no new secret, runner, or bespoke cache instance** — everything routes through the existing shared ci-templates surface + GloriousFlywheel substrate.

## Real attach, not nominal

Real enrollment is proven only by remote cache hit/transfer lines in the cache-backed validation step log. A green build with only `--disk_cache` is documented as **not** enrollment.

## Validation

- `nix develop --command just check` green (yaml/json parse, manifest, internal-refs, js-bazel-runner-contract, flywheel-reapi-proof-contract, flywheel + ci-cached endpoint-free, cache-backed-optin-contract, gitleaks: no leaks).
- `actionlint .github/workflows/js-bazel-package.yml` clean.
- `cache-attachment-contract.sh` classification matrix unit-tested (compatibility-local-only / shared-cache-backed / strict / placeholder / bad-scheme / localhost ± proof / executor-without-cache / executor≠cache / REAPI-cell).
- Default-path byte-identical command proven via base-vs-HEAD diff of the `Validate Bazel targets` run block.

Refs TIN-2110, GF#889.