### PR TITLE
release: v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.3.0] — 2026-06-14
+
 ### Added
 
 - **`js-bazel-package.yml` opt-in `cache_backed` shared-cache lane (TIN-2110)** —


### PR DESCRIPTION
Promotes `## [Unreleased]` to `## [2.3.0]` in CHANGELOG.md to cut the v2.3.0 minor release.

v2.3.0 ships the TIN-2110 opt-in, default-off cache-backed Bazel lane in `js-bazel-package.yml` (PR #51, merge 16a0e7a). Minor bump per RELEASING.md (new optional reusable-workflow input + new shared scripts/bazelrc).

On merge to main with subject `release: v2.3.0`, `release.yml`'s `tag-on-release-commit` job cuts the immutable `v2.3.0` tag, moves the floating `@v2` tag, and creates the GitHub Release from the `## [2.3.0]` CHANGELOG section.

Refs TIN-2110.