### PR TITLE
changelog: move lint-runs-on to [2.4.0] (shipped after v2.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
-## [2.3.0] — 2026-06-14
+## [2.4.0] — 2026-06-14
 
 ### Added
 
@@ -23,7 +23,12 @@ Versioning: [SemVer 2.0](https://semver.org/).
   first semantic workflow-yaml lint in the repo and is wired into `just check`
   (`lint-runs-on-selftest` + `lint-runs-on-check`). First guardrail of the
   GloriousFlywheel enrollment paradigm (P0 #2 — kills the `runs-on: <repo>-nix`
-  mistake at author time).
+  mistake at author time). (Landed just after the v2.3.0 cut.)
+
+## [2.3.0] — 2026-06-14
+
+### Added
+
 - **`js-bazel-package.yml` opt-in `cache_backed` shared-cache lane (TIN-2110)** —
   a new boolean input (default `false`). When `true`, Bazel target validation
   runs a fail-closed cache-attachment contract step and then


### PR DESCRIPTION
Cosmetic CHANGELOG fix: `lint-runs-on` (PR #52) landed just **after** the v2.3.0 tag was cut, so it shipped in **v2.4.0** (tag + GH release already published). This moves its CHANGELOG entry from `[2.3.0]` to `[2.4.0]` to match the released tags. No code change.