### PR TITLE
feat(enrollment-gate): manifest-driven fail-closed substrate gate (TIN-2109)

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -99,6 +99,17 @@ on:
           byte-identically (zero behavior change for non-opted consumers).
         type: boolean
         default: false
+      substrate_mode:
+        description: >-
+          Optional operator override for the cache-backed lane's expected Bazel
+          substrate mode (compatibility-local-only | shared-cache-backed |
+          executor-backed). Used ONLY when cache_backed=true AND the consumer's
+          tinyland.repo.json does not declare enrollment.substrateMode (which is
+          the authoritative source, TIN-2109). When empty and the manifest is
+          silent, the lane defaults to shared-cache-backed. Has no effect on the
+          default (non-cache-backed) path.
+        type: string
+        default: ""
       package_dir:
         description: "Directory containing the Bazel-built publishable package"
         type: string
@@ -664,16 +675,36 @@ jobs:
           targets_quoted="$(printf '%q ' "${bazel_targets[@]}")"
           run_with_bazel_fetch_retry "Validate Bazel targets" "npx --yes @bazel/bazelisk build ${targets_quoted}--verbose_failures"
 
+      # Opt-in (cache_backed=true) manifest validation. This is a NEW conditional
+      # path; the default path above is untouched (byte-identical for non-opted
+      # consumers). Validates the consumer's tinyland.repo.json against the
+      # vendored ci-templates schema and FAILS CLOSED on an invalid manifest
+      # (TIN-2109). Network-free: the schema ships in the action.
+      - name: Validate repo manifest (cache-backed lane)
+        if: ${{ inputs.cache_backed }}
+        uses: tinyland-inc/ci-templates/.github/actions/repo-manifest-validate@v2
+        with:
+          path: ${{ env.WORKSPACE_DIR }}/tinyland.repo.json
+
       # Opt-in (cache_backed=true) shared-cache-backed validation. This is a NEW
       # conditional path; the default path above is untouched. CACHE-FIRST only:
       # no remote executor is ever wired here (TIN-1997 Option D / TIN-2110).
+      # The contract's EXPECTED MODE is manifest-driven (TIN-2109): it is read
+      # from enrollment.substrateMode in tinyland.repo.json (authoritative), not a
+      # hard-coded workflow default. Runner labels are fed so the contract rejects
+      # hosted / repo-shaped runner fallback (no silent degrade).
       - name: Assert shared-cache attachment (cache-backed lane)
         if: ${{ inputs.cache_backed }}
         shell: bash
+        env:
+          CI_TEMPLATES_REF: v2.5.0
+          SUBSTRATE_MODE_INPUT: ${{ inputs.substrate_mode }}
+          RUNNER_LABELS: ${{ join(runner.labels, ',') }}
         run: |
           set -euo pipefail
           # The contract script ships in this ci-templates repo; locate it from
-          # the checked-out caller workspace fallback, else fetch the pinned copy.
+          # the checked-out caller workspace fallback, else fetch the immutable
+          # pinned copy (CI_TEMPLATES_REF is the releasing tag, not floating v2).
           script="$RUNNER_TEMP/cache-attachment-contract.sh"
           if [ -f "$WORKSPACE_DIR/scripts/cache-attachment-contract.sh" ]; then
             script="$WORKSPACE_DIR/scripts/cache-attachment-contract.sh"
@@ -683,10 +714,29 @@ jobs:
               -o "$script"
             chmod +x "$script"
           fi
-          export GF_BAZEL_SUBSTRATE_MODE="${GF_BAZEL_SUBSTRATE_MODE:-shared-cache-backed}"
+
+          # Manifest-driven expected mode (TIN-2109). Authority order:
+          #   1. enrollment.substrateMode in the consumer's tinyland.repo.json
+          #   2. the substrate_mode workflow input (operator override)
+          #   3. existing default (shared-cache-backed) for back-compat
+          # When the manifest declares a mode that disagrees with the actual
+          # endpoint attachment, the contract script fails closed.
+          declared_mode=""
+          manifest="$WORKSPACE_DIR/tinyland.repo.json"
+          if [ -f "$manifest" ]; then
+            declared_mode="$(jq -r '.enrollment.substrateMode // empty' "$manifest")"
+          fi
+          if [ -z "$declared_mode" ]; then
+            declared_mode="$SUBSTRATE_MODE_INPUT"
+          fi
+          export GF_BAZEL_SUBSTRATE_MODE="${declared_mode:-shared-cache-backed}"
+          echo "::notice::cache-backed lane expected mode (manifest-driven): $GF_BAZEL_SUBSTRATE_MODE"
+
+          # Feed runner labels so the contract rejects hosted / repo-shaped
+          # runner fallback. A missing substrate is a deterministic failure,
+          # never a silent degrade to a GitHub-hosted build.
+          export GF_BAZEL_RUNNER_LABELS="$RUNNER_LABELS"
           bash "$script" --strict
-        env:
-          CI_TEMPLATES_REF: v2
 
       - name: Validate Bazel targets (cache-backed)
         if: ${{ inputs.cache_backed }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,61 @@ enrollment out to spokes.
 
 See `docs/js-bazel-package.md` (`cache_backed`) for the consumer-facing details.
 
+## Lace-up: the one copyable enrollment pattern (TIN-2109)
+
+A consumer enrolls in deterministic, fail-closed shared-cache validation by
+copying ONE pattern. Two edits, then a green build only happens when the
+substrate actually attaches on a shared cluster runner.
+
+**1. Declare the enrollment dimensions as first-class manifest fields** in
+`tinyland.repo.json`. `enrollment.substrateMode` is the AUTHORITATIVE expected
+mode the gate enforces (additive + optional; existing manifests still validate):
+
+```json
+"enrollment": {
+  "forgeScope": "Jesssullivan",
+  "operatorOverlay": "jesssullivan-infra",
+  "executionPool": "tinyland-nix",
+  "substrateMode": "shared-cache-backed"
+}
+```
+
+**2. Opt into the cache-backed lane** on the `js-bazel-package.yml` consumer
+call (runner_mode must resolve to a shared `tinyland-*` capability class — never
+`ubuntu-latest`, never a repo-shaped `<name>-nix` label):
+
+```yaml
+jobs:
+  package:
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@v2.5.0
+    with:
+      runner_mode: repo_owned
+      runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
+      cache_backed: true            # opt-in; default off (non-opted consumers unchanged)
+      bazel_targets: "//:typecheck //:pkg //:test"
+```
+
+What you get, deterministically:
+
+- the gate validates `tinyland.repo.json` against the schema and **fails closed**
+  on an invalid manifest;
+- the gate reads `enrollment.substrateMode` and feeds it to
+  `cache-attachment-contract.sh --strict` as the expected mode. Declared
+  `shared-cache-backed` + no cache attached ⇒ **declared-vs-actual mismatch,
+  fail closed** (no silent local-only build);
+- a hosted (`ubuntu-*`), bare `self-hosted`, or repo-shaped (`<name>-nix*`)
+  runner is **rejected** — a missing substrate is a deterministic failure, never
+  a degrade to a GitHub-hosted build;
+- the fetch fallback for the contract script is pinned to the immutable releasing
+  tag (`v2.5.0`), so a pure-consumer spoke gets a reproducible fetch.
+
+**Executor-backed is defined but not selected.** If a repo ever declares
+`enrollment.substrateMode: executor-backed`, the SAME gate requires the full
+executor contract (remote executor endpoint + `BAZEL_REMOTE_CACHE` + cluster
+runner class + `GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST`) and fails closed if any piece
+is missing. No current repo selects it (cache-first / TIN-1997 Option D); the
+contract exists so the gate is enforceable the moment a repo declares it.
+
 ## Releasing
 
 See `RELEASING.md`. On a `release: vX.Y.Z` commit to `main`, `release.yml` cuts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **First-class enrollment manifest fields (TIN-2109)** —
+  `schemas/tinyland-repo-manifest.schema.json` gains an optional, additive
+  `enrollment` object promoting the four GloriousFlywheel enrollment dimensions
+  (`forgeScope`, `operatorOverlay`, `executionPool`, `substrateMode`) from
+  `supply_chain.sbom.notes` prose to validated fields. `substrateMode` is an enum
+  (`compatibility-local-only` | `shared-cache-backed` | `executor-backed`). The
+  object is back-compatible: existing manifests without it still validate, and it
+  is not globally required.
+- **Manifest-driven, fail-closed enrollment gate (TIN-2109)** — when
+  `cache_backed: true`, `js-bazel-package.yml` now (1) validates the consumer's
+  `tinyland.repo.json` against the vendored schema and **fails closed** on an
+  invalid manifest; (2) reads `enrollment.substrateMode` as the **authoritative**
+  expected mode fed to `cache-attachment-contract.sh --strict` (a manifest
+  declaring `shared-cache-backed` while no cache attaches fails closed, instead
+  of the previous hard-coded workflow default); and (3) feeds the runner labels
+  so the contract **rejects hosted (`ubuntu-*`) / bare `self-hosted` /
+  repo-shaped (`<name>-nix*`) runner fallback** — a missing substrate is a
+  deterministic failure, never a silent degrade to a GitHub-hosted build. All new
+  steps live inside the opt-in `cache_backed` path; the default
+  `bazelisk build … --verbose_failures` step is byte-identical for non-opted
+  consumers.
+- **`substrate_mode` workflow input** — optional operator override for the
+  cache-backed lane's expected mode, used only when the consumer manifest does
+  not declare `enrollment.substrateMode` (which remains authoritative). No effect
+  on the default path.
+- **Executor-backed contract DEFINED + ENFORCED (cache-first, never selected)** —
+  `scripts/cache-attachment-contract.sh` now requires the full executor contract
+  (remote executor endpoint + `BAZEL_REMOTE_CACHE` + a cluster runner class for
+  platform identity + a digest-pinned REAPI proof image via
+  `GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST`) whenever the declared/effective mode is
+  `executor-backed`, failing closed if any piece is missing. No current repo
+  selects executor-backed (TIN-1997 Option D / cache-first); the contract is
+  defined so the gate is enforceable the moment a repo declares it. The workflow
+  remains executor-free (no `--remote_executor` / `BAZEL_REMOTE_EXECUTOR` /
+  `--config=executor-backed`), keeping the `cache-backed-optin-contract` guard
+  green.
+
+### Changed
+
+- **Pinned the cache-attachment-contract fetch fallback** in
+  `js-bazel-package.yml` from the floating `CI_TEMPLATES_REF=v2` major tag to the
+  immutable releasing tag `v2.5.0`, so pure-consumer spokes that have not
+  vendored the script get a reproducible fetch.
+- **`just check` / `validate-ci-templates.py cache-backed-optin-contract`** now
+  additionally asserts the manifest-validation step, manifest-driven expected
+  mode, runner-label rejection wiring, the pinned (non-floating) fetch fallback,
+  and the contract script's hosted-runner + executor-backed enforcement.
+
 ## [2.4.0] — 2026-06-14
 
 ### Added

--- a/Justfile
+++ b/Justfile
@@ -9,7 +9,7 @@ _default:
     @just --list --unsorted
 
 # Run all repository-local validation.
-check: yaml-parse json-parse repo-manifest-validate internal-refs-check js-bazel-runner-contract-check flywheel-reapi-proof-contract-check endpoint-free-check ci-cached-endpoint-free-check cache-backed-optin-contract-check secrets-scan-dir lint-runs-on-selftest lint-runs-on-check
+check: yaml-parse json-parse repo-manifest-validate internal-refs-check js-bazel-runner-contract-check flywheel-reapi-proof-contract-check endpoint-free-check ci-cached-endpoint-free-check cache-backed-optin-contract-check cache-contract-selftest secrets-scan-dir lint-runs-on-selftest lint-runs-on-check
     @echo "ci-templates checks passed."
 
 # Parse all GitHub workflow/action YAML with Ruby's stdlib YAML parser.
@@ -68,6 +68,12 @@ ci-cached-endpoint-free-check:
 # (no remote executor wired in the workflow's cache-backed path).
 cache-backed-optin-contract-check:
     cd {{ root }} && python3 scripts/validate-ci-templates.py cache-backed-optin-contract
+
+# Prove the cache-attachment contract's fail-closed paths actually fail closed
+# (declared-vs-actual mismatch, hosted/repo-label fallback, executor-backed
+# without the required set, plus the pre-existing endpoint guards). TIN-2109.
+cache-contract-selftest:
+    cd {{ root }} && bash scripts/cache-attachment-contract-selftest.sh
 
 # Scan current files for secrets.
 secrets-scan-dir:

--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ are vendored from `tinyland-inc/site.scaffold/docs/schemas/`. The
 schema-doc repo is the source of truth; this repo vendors at known
 stable paths so composite actions can `jsonschema` against them.
 
+`tinyland-repo-manifest.schema.json` carries first-class, validated **enrollment**
+fields (TIN-2109): `enrollment.forgeScope`, `enrollment.operatorOverlay`,
+`enrollment.executionPool`, and `enrollment.substrateMode`
+(`compatibility-local-only` | `shared-cache-backed` | `executor-backed`). The
+object is additive and optional — existing manifests without it still validate —
+and `substrateMode` is the authoritative expected mode the cache-backed gate
+enforces.
+
 ## Bazelrc fragments
 
 `bazelrc/flywheel.bazelrc` is endpoint-free. It defines safe behavior for
@@ -168,9 +176,17 @@ cache-attachment contract and then validates with
 --remote_upload_local_results=false`, reading the shared Bazel cache. This lane is
 cache-first only (TIN-1997 Option D / GF#889); it never wires a remote executor.
 On self-hosted Tinyland cluster runners, `nix-setup` exports `BAZEL_REMOTE_CACHE`
-from cluster DNS, so attach needs no new secret or infrastructure. See
-[`docs/js-bazel-package.md`](docs/js-bazel-package.md) (`cache_backed`) and
-[`AGENTS.md`](AGENTS.md) for the enrollment doctrine.
+from cluster DNS, so attach needs no new secret or infrastructure.
+
+The cache-backed lane is **hardened for deterministic, fail-closed enrollment**
+(TIN-2109): it validates the consumer's `tinyland.repo.json` against the schema,
+reads `enrollment.substrateMode` as the authoritative expected mode (a
+declared-vs-actual mismatch fails closed), rejects hosted / repo-shaped runner
+fallback (no silent degrade to a GitHub-hosted build), and pins the contract-script
+fetch fallback to an immutable releasing tag. Copy the single **lace-up** pattern
+in [`AGENTS.md`](AGENTS.md) to enroll. See
+[`docs/js-bazel-package.md`](docs/js-bazel-package.md) (`cache_backed`,
+`substrate_mode`) for the consumer-facing details.
 
 ## Contributing
 

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -128,10 +128,22 @@ TIN-2110 cache-first enrollment surface (TIN-1997 Option D, proven by GF#889).
     `npx --yes @bazel/bazelisk build <targets> --verbose_failures` path,
     byte-identically. Non-opted consumers see zero behavior change.
 - `true`
-  - a fail-closed cache-attachment contract step runs first
+  - the consumer's `tinyland.repo.json` is validated against the vendored
+    ci-templates schema (network-free); an invalid manifest **fails closed**
+    (TIN-2109)
+  - a fail-closed cache-attachment contract step runs next
     (`scripts/cache-attachment-contract.sh --strict`), rejecting unexpanded
     `${...}` placeholders, non-`grpc`/`http` endpoints, and localhost endpoints
     (unless `GF_BAZEL_ALLOW_LOCALHOST_PROOF=true`)
+  - the contract's **expected mode is manifest-driven** (TIN-2109): it is read
+    from `enrollment.substrateMode` in `tinyland.repo.json`. If the manifest
+    declares `shared-cache-backed` but no cache actually attaches, the lane
+    **fails closed** (declared-vs-actual mismatch) instead of silently degrading
+  - the contract **rejects hosted / repo-shaped runner fallback**: the runner
+    labels are inspected and a GitHub-hosted (`ubuntu-*`), bare `self-hosted`, or
+    repo-shaped (`<name>-nix*`) runner is a deterministic failure, never a silent
+    degrade to a hosted build (override only with
+    `GF_BAZEL_ALLOW_HOSTED_RUNNER=true`)
   - the Bazel validation then runs
     `--config=ci-cached --remote_cache=$BAZEL_REMOTE_CACHE
     --remote_upload_local_results=false`, reading the shared Bazel cache
@@ -139,10 +151,19 @@ TIN-2110 cache-first enrollment surface (TIN-1997 Option D, proven by GF#889).
     silently building local-only
 
 `cache_backed` is **cache-first only**. It never wires a remote executor; REAPI /
-remote execution is out of scope for this lane. On self-hosted Tinyland cluster
-runners, `nix-setup` exports `BAZEL_REMOTE_CACHE` from cluster DNS, so attach
-needs no new secret or infrastructure; off-cluster, supply the endpoint via a
-repo/org secret or a wrapping step before validation.
+remote execution is out of scope for this lane (the workflow contains no
+executor flag or endpoint). On self-hosted Tinyland cluster runners, `nix-setup`
+exports `BAZEL_REMOTE_CACHE` from cluster DNS, so attach needs no new secret or
+infrastructure; off-cluster, supply the endpoint via a repo/org secret or a
+wrapping step before validation.
+
+The contract script also **defines and enforces** the `executor-backed` contract
+for any repo that declares `enrollment.substrateMode: executor-backed`: it then
+requires the full set (remote executor endpoint + `BAZEL_REMOTE_CACHE` + a
+cluster runner class for platform identity + a digest-pinned REAPI proof image,
+`GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST`) and fails closed if any piece is missing.
+**No current repo selects executor-backed** (cache-first / Option D); the contract
+is defined so the gate is enforceable the moment a repo declares it.
 
 Consumers opting in must:
 
@@ -158,6 +179,21 @@ Consumers opting in must:
 Real enrollment is proven by remote cache hit/transfer lines in the cache-backed
 validation step log. A green build that shows only `--disk_cache` and no remote
 transfer is **not** enrollment.
+
+When the consumer has not vendored `scripts/cache-attachment-contract.sh`, the
+workflow fetches it from an **immutable releasing tag** (the fallback ref is
+pinned to `v2.5.0`, not the floating `v2` major), so pure-consumer spokes get a
+reproducible fetch.
+
+### `substrate_mode`
+
+Optional operator override for the cache-backed lane's expected substrate mode
+(`compatibility-local-only` | `shared-cache-backed` | `executor-backed`). It is
+used **only** when `cache_backed: true` and the consumer's `tinyland.repo.json`
+does not declare `enrollment.substrateMode` — the manifest is the authoritative
+source (TIN-2109). When both are empty the lane defaults to
+`shared-cache-backed`. This input has no effect on the default
+(non-cache-backed) path.
 
 ### `github_package_name`
 

--- a/schemas/tinyland-repo-manifest.schema.json
+++ b/schemas/tinyland-repo-manifest.schema.json
@@ -106,6 +106,32 @@
 				"package_registry": { "type": "string" }
 			}
 		},
+		"enrollment": {
+			"type": "object",
+			"description": "First-class declaration of the four GloriousFlywheel enrollment dimensions. ADDITIVE + optional (TIN-2109): existing manifests without this object still validate. When present, `substrateMode` is the AUTHORITATIVE expected mode fed to scripts/cache-attachment-contract.sh --strict in the cache-backed lane; a declared-vs-actual mismatch fails closed.",
+			"additionalProperties": false,
+			"properties": {
+				"forgeScope": {
+					"type": "string",
+					"minLength": 1,
+					"description": "Forge account / org that owns the repo (e.g. a personal account or a tinyland-inc org scope)."
+				},
+				"operatorOverlay": {
+					"type": "string",
+					"minLength": 1,
+					"description": "Operator overlay that provisions the repo's runners/secrets (e.g. jesssullivan-infra)."
+				},
+				"executionPool": {
+					"type": "string",
+					"minLength": 1,
+					"description": "Execution pool the lanes target (e.g. tinyland-nix in-cluster ARC)."
+				},
+				"substrateMode": {
+					"$ref": "#/$defs/substrateMode",
+					"description": "Authoritative Bazel substrate mode. compatibility-local-only = no shared cache; shared-cache-backed = cache-first (TIN-1997 Option D); executor-backed = REAPI executor (DEFINED + ENFORCED but not selected by any current repo)."
+				}
+			}
+		},
 		"supply_chain": {
 			"type": "object",
 			"required": ["sbom"],
@@ -185,6 +211,13 @@
 				"gitops-receiver",
 				"ci-template-library",
 				"infra-substrate"
+			]
+		},
+		"substrateMode": {
+			"enum": [
+				"compatibility-local-only",
+				"shared-cache-backed",
+				"executor-backed"
 			]
 		}
 	}

--- a/scripts/cache-attachment-contract-selftest.sh
+++ b/scripts/cache-attachment-contract-selftest.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# TIN-2109 negative-test harness for scripts/cache-attachment-contract.sh.
+#
+# Proves the fail-closed paths actually fail closed and the happy paths pass,
+# WITHOUT running Bazel or touching the network. Each case asserts an exact exit
+# code (0 = attach OK, 1 = fail closed) so a regression flips a check.
+#
+# Run: scripts/cache-attachment-contract-selftest.sh
+# Wired into `just check` via `cache-contract-selftest`.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+contract="${here}/cache-attachment-contract.sh"
+
+if [[ ! -x ${contract} ]]; then
+  echo "ERROR: contract script not found/executable at ${contract}" >&2
+  exit 2
+fi
+
+pass=0
+fail=0
+
+# run_case <expected_exit> <description> [VAR=val ...]
+run_case() {
+  local expected="$1"
+  local desc="$2"
+  shift 2
+  local out actual
+  set +e
+  out="$(env -i PATH="$PATH" "$@" bash "${contract}" --strict 2>&1)"
+  actual=$?
+  set -e
+  if [[ ${actual} -eq ${expected} ]]; then
+    pass=$((pass + 1))
+    printf 'ok   [exit %d] %s\n' "${actual}" "${desc}"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL [exit %d, want %d] %s\n' "${actual}" "${expected}" "${desc}"
+    printf '       last: %s\n' "$(printf '%s\n' "${out}" | tail -1)"
+  fi
+}
+
+CACHE="grpcs://gf-reapi-cell.internal:443"
+
+echo "== happy paths (exit 0) =="
+# Current kit/bridge shape: cache attaches, declared shared-cache-backed, cluster runner.
+run_case 0 "shared-cache attaches on cluster runner, declared shared-cache-backed" \
+  BAZEL_REMOTE_CACHE="${CACHE}" GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed GF_BAZEL_RUNNER_LABELS=tinyland-nix
+# Back-compat: no runner labels supplied (pre-TIN-2109 callers).
+run_case 0 "shared-cache attaches, no runner labels supplied (back-compat)" \
+  BAZEL_REMOTE_CACHE="${CACHE}" GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed
+# Full executor contract present => executor-backed classification passes.
+run_case 0 "executor-backed full contract present" \
+  BAZEL_REMOTE_EXECUTOR="${CACHE}" BAZEL_REMOTE_CACHE="${CACHE}" \
+  GF_BAZEL_RUNNER_LABELS=tinyland-nix GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST=sha256:deadbeef \
+  GF_BAZEL_SUBSTRATE_MODE=executor-backed
+
+echo "== declared-vs-actual mismatch (exit 1) =="
+run_case 1 "declared shared-cache-backed but no cache attaches" \
+  GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed
+run_case 1 "declared compatibility-local-only but a cache IS attached" \
+  BAZEL_REMOTE_CACHE="${CACHE}" GF_BAZEL_SUBSTRATE_MODE=compatibility-local-only GF_BAZEL_RUNNER_LABELS=tinyland-nix
+
+echo "== hosted / repo-label fallback rejection (exit 1) =="
+run_case 1 "hosted ubuntu-latest runner" \
+  BAZEL_REMOTE_CACHE="${CACHE}" GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed GF_BAZEL_RUNNER_LABELS=ubuntu-latest
+run_case 1 "repo-shaped <name>-nix runner label" \
+  BAZEL_REMOTE_CACHE="${CACHE}" GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed GF_BAZEL_RUNNER_LABELS=jesssullivan-nix-heavy
+run_case 1 "bare self-hosted label (no capability class)" \
+  BAZEL_REMOTE_CACHE="${CACHE}" GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed GF_BAZEL_RUNNER_LABELS=self-hosted
+
+echo "== executor-backed without required set (exit 1) =="
+run_case 1 "executor endpoint set but no cache" \
+  BAZEL_REMOTE_EXECUTOR="${CACHE}" GF_BAZEL_RUNNER_LABELS=tinyland-nix
+run_case 1 "executor+cache+cluster but no REAPI proof image digest" \
+  BAZEL_REMOTE_EXECUTOR="${CACHE}" BAZEL_REMOTE_CACHE="${CACHE}" GF_BAZEL_RUNNER_LABELS=tinyland-nix
+run_case 1 "executor full set but hosted runner (no platform identity)" \
+  BAZEL_REMOTE_EXECUTOR="${CACHE}" BAZEL_REMOTE_CACHE="${CACHE}" \
+  GF_BAZEL_RUNNER_LABELS=ubuntu-latest GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST=sha256:deadbeef
+
+echo "== pre-existing endpoint fail-closed (exit 1) =="
+run_case 1 "unexpanded \${...} placeholder cache endpoint" \
+  BAZEL_REMOTE_CACHE='${BAZEL_REMOTE_CACHE}' GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed
+run_case 1 "non-grpc/http cache endpoint scheme" \
+  BAZEL_REMOTE_CACHE='ftp://cache' GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed
+run_case 1 "localhost cache without GF_BAZEL_ALLOW_LOCALHOST_PROOF" \
+  BAZEL_REMOTE_CACHE='grpc://localhost:9092' GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed
+run_case 1 "strict with empty BAZEL_REMOTE_CACHE (compat declared compat)" \
+  GF_BAZEL_SUBSTRATE_MODE=compatibility-local-only
+
+echo
+echo "cache-attachment-contract self-test: ${pass} passed, ${fail} failed"
+if [[ ${fail} -ne 0 ]]; then
+  exit 1
+fi

--- a/scripts/cache-attachment-contract.sh
+++ b/scripts/cache-attachment-contract.sh
@@ -11,9 +11,14 @@
 # MI logic verbatim.
 #
 # Classification:
-#   BAZEL_REMOTE_EXECUTOR set  => executor-backed   (out of scope this lane; classified, never selected)
+#   BAZEL_REMOTE_EXECUTOR set  => executor-backed   (DEFINED + ENFORCED; never selected by any current repo)
 #   else BAZEL_REMOTE_CACHE set => shared-cache-backed
 #   else                        => compatibility-local-only
+#
+# The DECLARED mode is GF_BAZEL_SUBSTRATE_MODE. TIN-2109 makes this manifest-driven:
+# the cache-backed lane reads tinyland.repo.json `enrollment.substrateMode` and
+# exports it as GF_BAZEL_SUBSTRATE_MODE so the manifest is the AUTHORITATIVE
+# expected mode. Declared-vs-actual is the effective_mode != expected_mode check.
 #
 # Fail-closed (exit 1) when:
 #   - either endpoint contains a literal ${...} placeholder (unexpanded secret/var)
@@ -23,6 +28,14 @@
 #   - executor != cache unless GF_BAZEL_ALLOW_SEPARATE_EXECUTOR_CACHE=true
 #   - declared GF_BAZEL_SUBSTRATE_MODE disagreeing with endpoint presence
 #   - --strict with an empty BAZEL_REMOTE_CACHE
+#   - (TIN-2109) --strict on a hosted / repo-shaped runner: a missing substrate is a
+#     deterministic failure, never a silent degrade to a GitHub-hosted build. Gated by
+#     GF_BAZEL_RUNNER_LABELS; reject ubuntu-*/windows-*/macos-*/bare self-hosted and any
+#     repo-shaped <name>-nix* label. Override only with GF_BAZEL_ALLOW_HOSTED_RUNNER=true.
+#   - (TIN-2109) declared/effective mode executor-backed without the FULL executor
+#     contract: BAZEL_REMOTE_EXECUTOR + BAZEL_REMOTE_CACHE + a cluster runner class +
+#     a proof-artifact image digest (GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST). This contract
+#     is DEFINED + ENFORCED but selected by no current repo (cache-first / Option D).
 
 set -euo pipefail
 
@@ -47,6 +60,19 @@ Environment:
   GF_BAZEL_ALLOW_SEPARATE_EXECUTOR_CACHE
                             Set true to permit executor != cache (default: GF REAPI cell
                             uses one endpoint for both).
+  GF_BAZEL_RUNNER_LABELS    Optional comma/space-separated runner labels. When set under
+                            --strict the gate REJECTS hosted (ubuntu-*/windows-*/macos-*),
+                            bare self-hosted, and repo-shaped (<name>-nix*) labels so a
+                            missing substrate fails closed instead of degrading to a
+                            GitHub-hosted build. Cluster classes: tinyland-nix,
+                            tinyland-nix-heavy, tinyland-nix-kvm, tinyland-nix-gpu,
+                            tinyland-docker, tinyland-dind.
+  GF_BAZEL_ALLOW_HOSTED_RUNNER
+                            Set true to bypass the hosted/repo-label rejection (explicit
+                            escape hatch only; the shared lane never enables it).
+  GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST
+                            Digest-pinned REAPI worker image. REQUIRED when the declared/
+                            effective mode is executor-backed (proof-artifact wiring).
 EOF
 }
 
@@ -125,6 +151,58 @@ endpoint_is_localhost() {
   esac
 }
 
+# --- TIN-2109: runner-class classification (reject hosted / repo-label fallback) ---
+# Cluster capability classes accepted for substrate-backed work. Anything else
+# (GitHub-hosted, bare self-hosted, or a repo-shaped <name>-nix* label) is a
+# silent-degrade vector and must fail closed in --strict.
+runner_labels_raw="${GF_BAZEL_RUNNER_LABELS:-}"
+allow_hosted_runner="${GF_BAZEL_ALLOW_HOSTED_RUNNER:-false}"
+runner_class=""
+runner_reject_reason=""
+is_cluster_label() {
+  case "$1" in
+  tinyland-nix | tinyland-nix-heavy | tinyland-nix-kvm | tinyland-nix-gpu | tinyland-docker | tinyland-dind)
+    return 0 ;;
+  *) return 1 ;;
+  esac
+}
+classify_runner() {
+  # Sets runner_class to the first cluster-class label found. If none, sets
+  # runner_reject_reason to the first disqualifying label (hosted / bare
+  # self-hosted / repo-shaped), else leaves both empty (no labels supplied).
+  local raw="$1"
+  raw="${raw//,/ }"
+  local label
+  for label in ${raw}; do
+    if is_cluster_label "${label}"; then
+      runner_class="${label}"
+      return 0
+    fi
+  done
+  for label in ${raw}; do
+    case "${label}" in
+    ubuntu-* | windows-* | macos-* | ubuntu | windows | macos)
+      runner_reject_reason="hosted GitHub runner label '${label}'"
+      return 0
+      ;;
+    self-hosted)
+      runner_reject_reason="bare 'self-hosted' label (no capability class)"
+      return 0
+      ;;
+    *-nix | *-nix-* | *-docker | *-dind)
+      runner_reject_reason="repo-shaped runner label '${label}' (not a shared tinyland capability class)"
+      return 0
+      ;;
+    esac
+  done
+  if [[ -n ${raw// /} ]]; then
+    runner_reject_reason="no tinyland capability-class label in '${raw}'"
+  fi
+}
+if [[ -n ${runner_labels_raw} ]]; then
+  classify_runner "${runner_labels_raw}"
+fi
+
 allow_localhost="${GF_BAZEL_ALLOW_LOCALHOST_PROOF:-false}"
 localhost_cache=false
 if [[ -n ${remote_cache} ]] && endpoint_is_localhost "${remote_cache}"; then
@@ -143,6 +221,7 @@ Bazel mode:         ${effective_mode}
 Bazel remote cache: ${remote_cache:-unset}
 Bazel executor:     ${remote_executor:-unset}
 Expected mode:      ${expected_mode}
+Runner class:       ${runner_class:-${runner_labels_raw:+unclassified (${runner_labels_raw})}}
 Strict:             ${STRICT}
 
 Contract:
@@ -209,6 +288,44 @@ if [[ -n ${remote_executor} && -n ${remote_cache} &&
   echo
   echo "ERROR: executor-backed mode requires BAZEL_REMOTE_CACHE to match BAZEL_REMOTE_EXECUTOR for the GloriousFlywheel REAPI cell."
   exit 1
+fi
+
+# TIN-2109: reject hosted / repo-shaped runner fallback under --strict. A
+# missing substrate must be a deterministic failure, never a silent degrade to a
+# GitHub-hosted build. Only enforced when runner labels are supplied AND --strict
+# is on, so non-cache-backed callers stay unaffected.
+if [[ ${STRICT} == "true" && -n ${runner_labels_raw} && -z ${runner_class} &&
+  ${allow_hosted_runner} != "true" ]]; then
+  echo
+  echo "ERROR: strict cache-backed lane refuses to run on ${runner_reject_reason:-a non-cluster runner}. The substrate must attach on a shared tinyland capability-class runner (tinyland-nix, tinyland-nix-heavy, tinyland-nix-kvm, tinyland-nix-gpu, tinyland-docker, tinyland-dind). Hosted/repo-label fallback is rejected; set GF_BAZEL_ALLOW_HOSTED_RUNNER=true only with explicit non-shared-lane justification."
+  exit 1
+fi
+
+# TIN-2109: executor-backed contract. When the declared/effective mode is
+# executor-backed, the FULL contract is required and any missing piece fails
+# closed. This is DEFINED + ENFORCED here but selected by NO current repo
+# (cache-first / TIN-1997 Option D); kit/bridge declare shared-cache-backed.
+if [[ ${effective_mode} == "executor-backed" || -n ${remote_executor} ]]; then
+  if [[ -z ${remote_executor} ]]; then
+    echo
+    echo "ERROR: declared substrateMode=executor-backed requires BAZEL_REMOTE_EXECUTOR (the REAPI executor endpoint)."
+    exit 1
+  fi
+  if [[ -z ${remote_cache} ]]; then
+    echo
+    echo "ERROR: executor-backed mode requires BAZEL_REMOTE_CACHE (the CAS/action-cache authority)."
+    exit 1
+  fi
+  if [[ -n ${runner_labels_raw} && -z ${runner_class} && ${allow_hosted_runner} != "true" ]]; then
+    echo
+    echo "ERROR: executor-backed mode requires a cluster runner class for platform identity (@gloriousflywheel//platforms:linux-x86_64); got ${runner_reject_reason:-no capability-class label}."
+    exit 1
+  fi
+  if [[ -z ${GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST:-} ]]; then
+    echo
+    echo "ERROR: executor-backed mode requires GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST (the digest-pinned REAPI worker image for proof-artifact wiring). The flywheel-reapi-proof authority must publish evidence with remote_processes > 0 and a worker_image_digest before a target class is proved."
+    exit 1
+  fi
 fi
 
 if [[ ${STRICT} == "true" && -z ${remote_cache} ]]; then

--- a/scripts/validate-ci-templates.py
+++ b/scripts/validate-ci-templates.py
@@ -228,11 +228,50 @@ def check_cache_backed_optin_contract() -> int:
         # the unchanged default command must still be present verbatim
         'run_with_bazel_fetch_retry "Validate Bazel targets" '
         '"npx --yes @bazel/bazelisk build ${targets_quoted}--verbose_failures"',
+        # TIN-2109: manifest validation in the cache-backed lane (fail-closed)
+        "Validate repo manifest (cache-backed lane)",
+        "repo-manifest-validate@v2",
+        # TIN-2109: expected mode is manifest-driven (enrollment.substrateMode)
+        ".enrollment.substrateMode",
+        "GF_BAZEL_SUBSTRATE_MODE=",
+        # TIN-2109: runner labels fed so the contract rejects hosted/repo-label fallback
+        "GF_BAZEL_RUNNER_LABELS=",
+        "join(runner.labels, ',')",
+        # TIN-2109: fetch fallback pinned to the immutable releasing tag, not floating v2
+        "CI_TEMPLATES_REF: v2.5.0",
     ]
     for snippet in required_workflow_snippets:
         if snippet not in workflow:
             print(
                 f"{workflow_path.relative_to(ROOT)}: missing cache-backed snippet: {snippet}",
+                file=sys.stderr,
+            )
+            ok = False
+
+    # TIN-2109: the floating-major fallback ref must NOT appear (it is pinned).
+    if re.search(r"CI_TEMPLATES_REF:\s*v2\s*$", workflow, re.MULTILINE):
+        print(
+            f"{workflow_path.relative_to(ROOT)}: cache-backed fetch fallback uses floating "
+            "CI_TEMPLATES_REF: v2; pin to the immutable releasing tag",
+            file=sys.stderr,
+        )
+        ok = False
+
+    # TIN-2109: the contract script must DEFINE+ENFORCE the hardened gate behaviors.
+    contract = contract_path.read_text(encoding="utf-8") if contract_path.exists() else ""
+    required_contract_snippets = [
+        # hosted / repo-shaped runner rejection (no silent degrade)
+        "GF_BAZEL_RUNNER_LABELS",
+        "GF_BAZEL_ALLOW_HOSTED_RUNNER",
+        "classify_runner",
+        # executor-backed contract: full required set, defined + enforced
+        "GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST",
+        'executor-backed mode requires BAZEL_REMOTE_CACHE',
+    ]
+    for snippet in required_contract_snippets:
+        if snippet not in contract:
+            print(
+                f"{contract_path.relative_to(ROOT)}: missing TIN-2109 contract snippet: {snippet}",
                 file=sys.stderr,
             )
             ok = False

--- a/tinyland.repo.json
+++ b/tinyland.repo.json
@@ -46,6 +46,12 @@
     "tofu_module_authority": "tinyland-inc/GloriousFlywheel",
     "package_registry": "tinyland-inc/bazel-registry"
   },
+  "enrollment": {
+    "forgeScope": "tinyland-inc",
+    "operatorOverlay": "tinyland-infra",
+    "executionPool": "tinyland-nix",
+    "substrateMode": "compatibility-local-only"
+  },
   "supply_chain": {
     "sbom": {
       "status": "not-required",


### PR DESCRIPTION
## TIN-2109 — harden the enrollment contract

Makes a missing Bazel substrate a **deterministic, fail-closed failure** instead of a silent degrade. Everything new is **opt-in (`cache_backed: true`), default-off, and additive**; the default `Validate Bazel targets` path is **byte-identical** for the ~190 non-opted consumers.

> Note: `v2.4.0` was cut (PR #54, lint-runs-on release) while this was in flight. This PR therefore targets **v2.5.0** as the releasing tag.

### What changed

1. **First-class enrollment manifest fields** — `schemas/tinyland-repo-manifest.schema.json` gains an optional, additive `enrollment` object: `forgeScope`, `operatorOverlay`, `executionPool`, and `substrateMode` (enum `compatibility-local-only | shared-cache-backed | executor-backed`). Existing manifests without it still validate (proven).
2. **Manifest validation in the cache-backed lane** — `cache_backed: true` now validates the consumer's `tinyland.repo.json` against the vendored schema and **fails closed** on an invalid manifest (network-free; schema ships in the action).
3. **Declared-vs-actual fail-closed gate** — `enrollment.substrateMode` is now the **authoritative** expected mode fed to `cache-attachment-contract.sh --strict`, replacing the hard-coded workflow default. Declared `shared-cache-backed` + no cache attached ⇒ fail closed.
4. **Reject hosted / repo-label fallback** — the contract inspects runner labels under `--strict` and rejects hosted (`ubuntu-*`), bare `self-hosted`, and repo-shaped (`<name>-nix*`) runners. A missing substrate never degrades to a GitHub-hosted build (override only with `GF_BAZEL_ALLOW_HOSTED_RUNNER=true`).
5. **Executor-backed contract DEFINED + ENFORCED, never selected** — for any repo that declares `substrateMode: executor-backed`, the contract requires the full set (remote executor endpoint + `BAZEL_REMOTE_CACHE` + cluster runner class for platform identity + `GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST`) and fails closed if any piece is missing. **No current repo selects it** (cache-first / TIN-1997 Option D); the workflow stays executor-free so the `cache-backed-optin-contract` guard remains green.
6. **Pinned fetch fallback** — `CI_TEMPLATES_REF` for the curl fallback moves from floating `v2` to the immutable releasing tag `v2.5.0`.
7. **Docs** — one copyable **lace-up** enrollment pattern in `AGENTS.md`, plus `README.md` / `docs/js-bazel-package.md` updates (`cache_backed`, `substrate_mode`).
8. **Negative-test harness** — `scripts/cache-attachment-contract-selftest.sh` (15 cases) wired into `just check`; `validate-ci-templates.py` extended to guard the new gate wiring.

### Byte-identical proof (default path)

The default `Validate Bazel targets` step (`if: ${{ !inputs.cache_backed }}`) is byte-identical to v2.3.0 — verified by extracting and `diff`-ing the step from the released tag vs HEAD (no `+`/`-` lines on the step). All new steps are gated `if: ${{ inputs.cache_backed }}`.

### Negative tests (all pass)

`scripts/cache-attachment-contract-selftest.sh`: **15 passed, 0 failed** —
- declared-vs-actual mismatch (declared shared-cache-backed, no cache) → exit 1
- declared compatibility-local-only while a cache IS attached → exit 1
- hosted `ubuntu-latest`, repo-shaped `<name>-nix-heavy`, bare `self-hosted` → exit 1
- executor-backed without cache / without proof digest / on hosted runner → exit 1
- pre-existing `${...}` placeholder / non-grpc scheme / localhost / empty-cache guards → exit 1
- happy paths (shared-cache + cluster runner; back-compat no labels; full executor set) → exit 0

### Release follow-up

This PR populates `## [Unreleased]`. After merge, cut **v2.5.0** (MINOR: additive optional schema fields + new opt-in gate steps), then bump kit/bridge from `@v2.3.0` to `@v2.5.0` and re-vendor the hardened `cache-attachment-contract.sh`. kit/bridge stay `shared-cache-backed`; no `--remote_executor` is wired.

### Bazel posture (agent)

Local disk cache only; no remote cache; no RBE for this agent's own builds. Consumer lanes (kit/bridge) are shared-cache-backed (read-only, no upload, no executor).