### PR TITLE
release: v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.5.0] — 2026-06-14
+
 ### Added
 
 - **First-class enrollment manifest fields (TIN-2109)** —


### PR DESCRIPTION
Cut v2.5.0 (MINOR): TIN-2109 manifest-driven fail-closed enrollment gate (additive optional schema fields + opt-in cache-backed gate steps). Moves `## [Unreleased]` contents into `## [2.5.0]`. On merge, release.yml tag-on-release-commit cuts the immutable v2.5.0 tag, moves @v2, and creates the GitHub Release.