### PR TITLE
fix(repo-manifest-validate): dependency-free validator for cluster runners (TIN-2109)

### DIFF
--- a/.github/actions/repo-manifest-validate/action.yml
+++ b/.github/actions/repo-manifest-validate/action.yml
@@ -30,10 +30,16 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        schema="${{ github.action_path }}/../../../schemas/tinyland-repo-manifest.schema.json"
+        action_dir="${{ github.action_path }}"
+        schema="$action_dir/../../../schemas/tinyland-repo-manifest.schema.json"
+        validator="$action_dir/../../../scripts/manifest-schema-validate.py"
         manifest="${{ inputs.path }}"
         if [[ ! -f "$schema" ]]; then
           echo "::error::ci-templates schema missing at $schema"
+          exit 1
+        fi
+        if [[ ! -f "$validator" ]]; then
+          echo "::error::ci-templates manifest validator missing at $validator"
           exit 1
         fi
         if [[ ! -f "$manifest" ]]; then
@@ -41,29 +47,16 @@ runs:
           exit 1
         fi
 
-        if python3 -c 'import jsonschema' >/dev/null 2>&1; then
-          validator=(python3)
-        elif command -v nix >/dev/null 2>&1 && [[ -f flake.nix ]]; then
-          validator=(nix develop --command python3)
-          echo "::notice::host python lacks jsonschema; validating via nix develop"
-        else
-          echo "::error::python jsonschema is unavailable and no flake.nix dev shell exists"
-          exit 2
+        # Dependency-free, network-free validation (TIN-2109). The validator
+        # prefers the authoritative `jsonschema` package when importable and
+        # otherwise uses a stdlib JSON-Schema-subset fallback, so the gate works
+        # on nix self-hosted cluster runners (where a cold `nix develop` can fail
+        # on a nix-store lock) as well as on hosted runners. Fail-closed: a
+        # non-zero exit (invalid manifest) fails the step.
+        if ! python3 -c 'import jsonschema' >/dev/null 2>&1; then
+          echo "::notice::host python lacks jsonschema; using bundled stdlib validator"
         fi
-
-        "${validator[@]}" - <<PY
-        import json, sys
-        from jsonschema import Draft202012Validator
-        schema = json.load(open("$schema"))
-        inst = json.load(open("$manifest"))
-        Draft202012Validator.check_schema(schema)
-        errors = sorted(Draft202012Validator(schema).iter_errors(inst), key=lambda e: list(e.absolute_path))
-        if errors:
-            for e in errors:
-                p = "/" + "/".join(str(x) for x in e.absolute_path)
-                print(f"::error file=$manifest::at {p}: {e.message}", file=sys.stderr)
-            sys.exit(1)
-        PY
+        python3 "$validator" "$schema" "$manifest"
 
     - name: Read manifest role
       id: read

--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -697,7 +697,7 @@ jobs:
         if: ${{ inputs.cache_backed }}
         shell: bash
         env:
-          CI_TEMPLATES_REF: v2.5.0
+          CI_TEMPLATES_REF: v2.5.1
           SUBSTRATE_MODE_INPUT: ${{ inputs.substrate_mode }}
           RUNNER_LABELS: ${{ join(runner.labels, ',') }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ call (runner_mode must resolve to a shared `tinyland-*` capability class — nev
 ```yaml
 jobs:
   package:
-    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@v2.5.0
+    uses: tinyland-inc/ci-templates/.github/workflows/js-bazel-package.yml@v2.5.1
     with:
       runner_mode: repo_owned
       runner_labels_json: ${{ vars.PRIMARY_LINUX_RUNNER_LABELS_JSON }}
@@ -118,7 +118,7 @@ What you get, deterministically:
   runner is **rejected** — a missing substrate is a deterministic failure, never
   a degrade to a GitHub-hosted build;
 - the fetch fallback for the contract script is pinned to the immutable releasing
-  tag (`v2.5.0`), so a pure-consumer spoke gets a reproducible fetch.
+  tag (`v2.5.1`), so a pure-consumer spoke gets a reproducible fetch.
 
 **Executor-backed is defined but not selected.** If a repo ever declares
 `enrollment.substrateMode: executor-backed`, the SAME gate requires the full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`repo-manifest-validate` runs without `jsonschema` or `nix` (TIN-2109)** —
+  the action now validates via a bundled, dependency-free stdlib validator
+  (`scripts/manifest-schema-validate.py`) that prefers the authoritative
+  `jsonschema` package when importable and otherwise falls back to a faithful
+  JSON-Schema-2020-12 subset validator. The previous `nix develop --command
+  python3` fallback failed on nix self-hosted cluster runners (a cold
+  `nix develop` hits an `opening lock file ".../big-lock": Permission denied`),
+  which made the v2.5.0 cache-backed manifest-validation gate fail closed for the
+  wrong reason. No network; fail-closed semantics unchanged.
+
 ## [2.5.0] — 2026-06-14
 
 ### Added

--- a/Justfile
+++ b/Justfile
@@ -9,7 +9,7 @@ _default:
     @just --list --unsorted
 
 # Run all repository-local validation.
-check: yaml-parse json-parse repo-manifest-validate internal-refs-check js-bazel-runner-contract-check flywheel-reapi-proof-contract-check endpoint-free-check ci-cached-endpoint-free-check cache-backed-optin-contract-check cache-contract-selftest secrets-scan-dir lint-runs-on-selftest lint-runs-on-check
+check: yaml-parse json-parse repo-manifest-validate manifest-validate-selftest internal-refs-check js-bazel-runner-contract-check flywheel-reapi-proof-contract-check endpoint-free-check ci-cached-endpoint-free-check cache-backed-optin-contract-check cache-contract-selftest secrets-scan-dir lint-runs-on-selftest lint-runs-on-check
     @echo "ci-templates checks passed."
 
 # Parse all GitHub workflow/action YAML with Ruby's stdlib YAML parser.
@@ -74,6 +74,15 @@ cache-backed-optin-contract-check:
 # without the required set, plus the pre-existing endpoint guards). TIN-2109.
 cache-contract-selftest:
     cd {{ root }} && bash scripts/cache-attachment-contract-selftest.sh
+
+# Prove the dependency-free manifest validator accepts the real manifest and
+# fails closed on an invalid one (no jsonschema/nix/network required). TIN-2109.
+manifest-validate-selftest:
+    cd {{ root }} && python3 scripts/manifest-schema-validate.py schemas/tinyland-repo-manifest.schema.json tinyland.repo.json
+    cd {{ root }} && bad=$(mktemp) && jq '.schema_version=2' tinyland.repo.json > "$bad" && \
+      if python3 scripts/manifest-schema-validate.py schemas/tinyland-repo-manifest.schema.json "$bad" 2>/dev/null; then \
+        echo "FAIL: validator did not reject an invalid manifest" >&2; rm -f "$bad"; exit 1; \
+      else echo "manifest validator fails closed on invalid manifest"; rm -f "$bad"; fi
 
 # Scan current files for secrets.
 secrets-scan-dir:

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -182,7 +182,7 @@ transfer is **not** enrollment.
 
 When the consumer has not vendored `scripts/cache-attachment-contract.sh`, the
 workflow fetches it from an **immutable releasing tag** (the fallback ref is
-pinned to `v2.5.0`, not the floating `v2` major), so pure-consumer spokes get a
+pinned to `v2.5.1`, not the floating `v2` major), so pure-consumer spokes get a
 reproducible fetch.
 
 ### `substrate_mode`

--- a/scripts/manifest-schema-validate.py
+++ b/scripts/manifest-schema-validate.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Dependency-free JSON Schema validator for the Tinyland repo manifest.
+
+Why this exists (TIN-2109): the cache-backed enrollment gate must validate the
+consumer's tinyland.repo.json against schemas/tinyland-repo-manifest.schema.json
+on ANY runner, with NO network and NO third-party package. The shared
+`repo-manifest-validate` action previously required either host `jsonschema` or a
+working `nix develop` dev shell; on nix self-hosted cluster runners a cold
+`nix develop` can fail (e.g. nix-store lock permission), which would make the
+fail-closed gate fail for the WRONG reason. This validator uses only the Python
+standard library.
+
+Scope: it implements the JSON Schema 2020-12 subset actually used by the manifest
+schema: type, required, properties, additionalProperties, enum, const, pattern,
+minLength, minItems, uniqueItems, items, $ref (local #/$defs/...), allOf, and
+if/then. `format` is accepted but not enforced (jsonschema treats most formats as
+annotations by default too). It is intentionally strict: unknown schema keywords
+are ignored (annotation-safe), but every constraint it does understand is
+enforced. When the real `jsonschema` package is importable it is preferred (so
+behavior matches the authoritative validator); this stdlib path is the fallback.
+
+Usage:
+  manifest-schema-validate.py <schema.json> <manifest.json>
+Exit codes: 0 valid, 1 invalid (errors printed), 2 usage/IO error.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+
+def _type_ok(value, expected) -> bool:
+    if isinstance(expected, list):
+        return any(_type_ok(value, t) for t in expected)
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "null":
+        return value is None
+    return True
+
+
+def _resolve_ref(root: dict, ref: str):
+    if not ref.startswith("#/"):
+        raise ValueError(f"unsupported $ref (only local refs): {ref}")
+    node = root
+    for part in ref[2:].split("/"):
+        part = part.replace("~1", "/").replace("~0", "~")
+        node = node[part]
+    return node
+
+
+def validate(instance, schema, root, path, errors) -> None:
+    if "$ref" in schema:
+        validate(instance, _resolve_ref(root, schema["$ref"]), root, path, errors)
+        # 2020-12 allows siblings to $ref; continue checking them too.
+
+    if "const" in schema and instance != schema["const"]:
+        errors.append(f"{path or '/'}: must equal const {schema['const']!r}")
+
+    if "enum" in schema and instance not in schema["enum"]:
+        errors.append(f"{path or '/'}: {instance!r} is not one of {schema['enum']}")
+
+    if "type" in schema and not _type_ok(instance, schema["type"]):
+        errors.append(f"{path or '/'}: is not of type {schema['type']!r}")
+
+    if isinstance(instance, str):
+        if "minLength" in schema and len(instance) < schema["minLength"]:
+            errors.append(f"{path or '/'}: shorter than minLength {schema['minLength']}")
+        if "pattern" in schema and re.search(schema["pattern"], instance) is None:
+            errors.append(f"{path or '/'}: does not match pattern {schema['pattern']!r}")
+
+    if isinstance(instance, list):
+        if "minItems" in schema and len(instance) < schema["minItems"]:
+            errors.append(f"{path or '/'}: fewer than minItems {schema['minItems']}")
+        if schema.get("uniqueItems") and len(
+            {json.dumps(i, sort_keys=True) for i in instance}
+        ) != len(instance):
+            errors.append(f"{path or '/'}: items are not unique")
+        if "items" in schema:
+            for idx, item in enumerate(instance):
+                validate(item, schema["items"], root, f"{path}/{idx}", errors)
+
+    if isinstance(instance, dict):
+        props = schema.get("properties", {})
+        for key in schema.get("required", []):
+            if key not in instance:
+                errors.append(f"{path or '/'}: missing required property '{key}'")
+        if schema.get("additionalProperties") is False:
+            for key in instance:
+                if key not in props:
+                    errors.append(f"{path or '/'}: additional property '{key}' is not allowed")
+        for key, subschema in props.items():
+            if key in instance:
+                validate(instance[key], subschema, root, f"{path}/{key}", errors)
+
+    for sub in schema.get("allOf", []):
+        validate(instance, sub, root, path, errors)
+
+    if "if" in schema:
+        cond_errors: list[str] = []
+        validate(instance, schema["if"], root, path, cond_errors)
+        if not cond_errors and "then" in schema:
+            validate(instance, schema["then"], root, path, errors)
+        elif cond_errors and "else" in schema:
+            validate(instance, schema["else"], root, path, errors)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print("usage: manifest-schema-validate.py <schema.json> <manifest.json>", file=sys.stderr)
+        return 2
+    schema_path, manifest_path = argv[1], argv[2]
+    try:
+        schema = json.loads(open(schema_path, encoding="utf-8").read())
+        instance = json.loads(open(manifest_path, encoding="utf-8").read())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"::error::cannot read schema/manifest: {exc}", file=sys.stderr)
+        return 2
+
+    # Prefer the authoritative validator when available.
+    try:
+        from jsonschema import Draft202012Validator
+
+        Draft202012Validator.check_schema(schema)
+        errs = sorted(
+            Draft202012Validator(schema).iter_errors(instance),
+            key=lambda e: list(e.absolute_path),
+        )
+        if errs:
+            for e in errs:
+                p = "/" + "/".join(str(x) for x in e.absolute_path)
+                print(f"::error file={manifest_path}::at {p}: {e.message}", file=sys.stderr)
+            return 1
+        return 0
+    except ImportError:
+        pass
+
+    errors: list[str] = []
+    validate(instance, schema, schema, "", errors)
+    if errors:
+        for msg in errors:
+            print(f"::error file={manifest_path}::{msg}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/validate-ci-templates.py
+++ b/scripts/validate-ci-templates.py
@@ -238,7 +238,7 @@ def check_cache_backed_optin_contract() -> int:
         "GF_BAZEL_RUNNER_LABELS=",
         "join(runner.labels, ',')",
         # TIN-2109: fetch fallback pinned to the immutable releasing tag, not floating v2
-        "CI_TEMPLATES_REF: v2.5.0",
+        "CI_TEMPLATES_REF: v2.5.1",
     ]
     for snippet in required_workflow_snippets:
         if snippet not in workflow:
@@ -256,6 +256,30 @@ def check_cache_backed_optin_contract() -> int:
             file=sys.stderr,
         )
         ok = False
+
+    # TIN-2109: the manifest validator must be dependency-free (no nix/network)
+    # so the gate works on nix self-hosted cluster runners.
+    validator_path = ROOT / "scripts/manifest-schema-validate.py"
+    action_path = ROOT / ".github/actions/repo-manifest-validate/action.yml"
+    if not validator_path.exists():
+        print(f"missing {validator_path.relative_to(ROOT)}", file=sys.stderr)
+        ok = False
+    if action_path.exists():
+        action_text = action_path.read_text(encoding="utf-8")
+        if "manifest-schema-validate.py" not in action_text:
+            print(
+                f"{action_path.relative_to(ROOT)}: repo-manifest-validate must use the "
+                "bundled stdlib validator (manifest-schema-validate.py)",
+                file=sys.stderr,
+            )
+            ok = False
+        if "nix develop --command python3" in action_text:
+            print(
+                f"{action_path.relative_to(ROOT)}: repo-manifest-validate must not depend on "
+                "`nix develop` (fails on nix-store lock on cluster runners)",
+                file=sys.stderr,
+            )
+            ok = False
 
     # TIN-2109: the contract script must DEFINE+ENFORCE the hardened gate behaviors.
     contract = contract_path.read_text(encoding="utf-8") if contract_path.exists() else ""


### PR DESCRIPTION
## Fix the v2.5.0 manifest-validation gate on nix cluster runners

The v2.5.0 cache-backed manifest-validation step (TIN-2109) failed closed for the **wrong reason** on nix self-hosted cluster runners: `repo-manifest-validate` fell back to `nix develop --command python3` (host python lacks `jsonschema`), and a cold `nix develop` hits `opening lock file ".../big-lock": Permission denied`. Observed on scheduling-kit PR #112 (`validate (22)` → step "Validate repo manifest (cache-backed lane)" failed).

### Change

- **`scripts/manifest-schema-validate.py`** — a dependency-free validator that prefers the authoritative `jsonschema` package when importable, and otherwise uses a faithful JSON-Schema-2020-12 **subset** validator (type, required, properties, additionalProperties, enum, const, pattern, minLength, minItems, uniqueItems, items, local `$ref`, allOf, if/then). Cross-checked against `jsonschema` on every valid + invalid fixture, including the static-spoke `if/then` boundary constraint — identical pass/fail.
- **`repo-manifest-validate` action** now calls the bundled validator: **no `nix`, no network**. Fail-closed semantics unchanged. Fixes the gate for all ~190 consumers, not just kit/bridge.
- Pin the cache-backed fetch fallback + lace-up examples to **v2.5.1**.
- Add `manifest-validate-selftest` to `just check`; guard the validator in `validate-ci-templates.py`.

### Proof

`just check` (all components) passes locally; `manifest-validate-selftest` accepts the real manifest and fails closed on `schema_version=2`. Default (non-cache-backed) Bazel path remains **byte-identical**. Cross-check: stdlib validator == `jsonschema` on 3 valid + 6 invalid fixtures.

### Release follow-up

Cut **v2.5.1** (PATCH) after merge; kit/bridge pin to v2.5.1.

Bazel posture (agent): local disk cache only; no remote cache; no RBE for the agent's builds. Consumer lanes shared-cache-backed (read-only, no upload, no executor).