### PR TITLE
release: v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.5.1] — 2026-06-14
+
 ### Fixed
 
 - **`repo-manifest-validate` runs without `jsonschema` or `nix` (TIN-2109)** —


### PR DESCRIPTION
Cut v2.5.1 (PATCH): make repo-manifest-validate dependency-free so the TIN-2109 cache-backed manifest-validation gate works on nix self-hosted cluster runners (no jsonschema/nix/network). Moves `## [Unreleased]` into `## [2.5.1]`. After merge, the immutable v2.5.1 tag is cut and @v2 is moved.