### PR TITLE
release: v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.6.0] — 2026-06-14
+
 ### Added
 
 - **Opt-in shared-cache enrollment gate for `spoke-ci.yml` (TIN-2119)** — the


### PR DESCRIPTION
Cuts v2.6.0 (MINOR): opt-in / default-off shared-cache enrollment gate for spoke-ci.yml (TIN-2119, #59). Moves the [Unreleased] entry into [2.6.0]. Tag is cut manually post-merge per RELEASING.md 3b (squash-merge appends (#NN) to the subject, so tag-on-release-commit does not auto-fire).