### PR TITLE
feat(flywheel): propagate profile state in cache lanes

### DIFF
--- a/.github/workflows/js-bazel-package.yml
+++ b/.github/workflows/js-bazel-package.yml
@@ -730,7 +730,10 @@ jobs:
             declared_mode="$SUBSTRATE_MODE_INPUT"
           fi
           export GF_BAZEL_SUBSTRATE_MODE="${declared_mode:-shared-cache-backed}"
+          export GF_FLYWHEEL_PROFILE_STATE="$GF_BAZEL_SUBSTRATE_MODE"
+          echo "GF_FLYWHEEL_PROFILE_STATE=$GF_FLYWHEEL_PROFILE_STATE" >> "$GITHUB_ENV"
           echo "::notice::cache-backed lane expected mode (manifest-driven): $GF_BAZEL_SUBSTRATE_MODE"
+          echo "::notice::Flywheel profile state: $GF_FLYWHEEL_PROFILE_STATE"
 
           # Feed runner labels so the contract rejects hosted / repo-shaped
           # runner fallback. A missing substrate is a deterministic failure,

--- a/.github/workflows/spoke-ci.yml
+++ b/.github/workflows/spoke-ci.yml
@@ -206,7 +206,10 @@ jobs:
             declared_mode="$SUBSTRATE_MODE_INPUT"
           fi
           export GF_BAZEL_SUBSTRATE_MODE="${declared_mode:-shared-cache-backed}"
+          export GF_FLYWHEEL_PROFILE_STATE="$GF_BAZEL_SUBSTRATE_MODE"
+          echo "GF_FLYWHEEL_PROFILE_STATE=$GF_FLYWHEEL_PROFILE_STATE" >> "$GITHUB_ENV"
           echo "::notice::cache-backed lane expected mode (manifest-driven): $GF_BAZEL_SUBSTRATE_MODE"
+          echo "::notice::Flywheel profile state: $GF_FLYWHEEL_PROFILE_STATE"
 
           export GF_BAZEL_RUNNER_LABELS="$RUNNER_LABELS"
           bash "$script" --strict
@@ -319,6 +322,9 @@ jobs:
             declared_mode="$SUBSTRATE_MODE_INPUT"
           fi
           export GF_BAZEL_SUBSTRATE_MODE="${declared_mode:-shared-cache-backed}"
+          export GF_FLYWHEEL_PROFILE_STATE="$GF_BAZEL_SUBSTRATE_MODE"
+          echo "GF_FLYWHEEL_PROFILE_STATE=$GF_FLYWHEEL_PROFILE_STATE" >> "$GITHUB_ENV"
+          echo "::notice::Flywheel profile state: $GF_FLYWHEEL_PROFILE_STATE"
           export GF_BAZEL_RUNNER_LABELS="$RUNNER_LABELS"
           bash "$script" --strict
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Versioning: [SemVer 2.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Flywheel profile-state propagation for cache-backed enrollment (TIN-2130)** —
+  cache-backed `js-bazel-package.yml` and `spoke-ci.yml` lanes now export
+  `GF_FLYWHEEL_PROFILE_STATE` from the manifest-driven substrate mode, and the
+  fail-closed cache attachment contract rejects contradictory profile states.
+  This gives consumer `flywheel-doctor` / `flywheel-verify` tooling the same
+  machine-readable attachment state as CI without minting tokens or changing the
+  cache-first/no-executor boundary.
+
 ## [2.6.0] — 2026-06-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -183,8 +183,11 @@ The cache-backed lane is **hardened for deterministic, fail-closed enrollment**
 reads `enrollment.substrateMode` as the authoritative expected mode (a
 declared-vs-actual mismatch fails closed), rejects hosted / repo-shaped runner
 fallback (no silent degrade to a GitHub-hosted build), and pins the contract-script
-fetch fallback to an immutable releasing tag. Copy the single **lace-up** pattern
-in [`AGENTS.md`](AGENTS.md) to enroll. See
+fetch fallback to an immutable releasing tag. It also exports
+`GF_FLYWHEEL_PROFILE_STATE` from the resolved substrate mode so consumer
+`flywheel-doctor` / `flywheel-verify` tooling sees the same machine-readable
+attachment state as CI. Copy the single **lace-up** pattern in
+[`AGENTS.md`](AGENTS.md) to enroll. See
 [`docs/js-bazel-package.md`](docs/js-bazel-package.md) (`cache_backed`,
 `substrate_mode`) for the consumer-facing details.
 
@@ -193,8 +196,9 @@ via `cache_backed` + `substrate_mode` (and `cache_backed_targets` for the
 SvelteKit flywheel-eligible CAS surface). When set, the `flywheel-build` and
 `bazel-graph` jobs switch from `setup-nix@v2` (install-only) to `nix-setup@v2`
 (which exports `BAZEL_REMOTE_CACHE` from cluster DNS — the spoke wiring fix),
-run the identical fail-closed contract, and execute a cache-backed Bazel build
-of the flywheel-eligible targets reading the shared cache. The default path is
+export `GF_FLYWHEEL_PROFILE_STATE` from the manifest-driven substrate mode, run
+the identical fail-closed contract, and execute a cache-backed Bazel build of
+the flywheel-eligible targets reading the shared cache. The default path is
 byte-identical for the ~34 non-opted spoke consumers. An opted spoke must also
 set `flywheel_config: flywheel` so `flywheel-bazel` forwards the remote cache.
 

--- a/docs/js-bazel-package.md
+++ b/docs/js-bazel-package.md
@@ -139,6 +139,9 @@ TIN-2110 cache-first enrollment surface (TIN-1997 Option D, proven by GF#889).
     from `enrollment.substrateMode` in `tinyland.repo.json`. If the manifest
     declares `shared-cache-backed` but no cache actually attaches, the lane
     **fails closed** (declared-vs-actual mismatch) instead of silently degrading
+  - the workflow exports `GF_FLYWHEEL_PROFILE_STATE` from the resolved substrate
+    mode so consumer `flywheel-doctor` / `flywheel-verify` commands see the
+    same machine-readable attachment state as CI
   - the contract **rejects hosted / repo-shaped runner fallback**: the runner
     labels are inspected and a GitHub-hosted (`ubuntu-*`), bare `self-hosted`, or
     repo-shaped (`<name>-nix*`) runner is a deterministic failure, never a silent

--- a/scripts/cache-attachment-contract-selftest.sh
+++ b/scripts/cache-attachment-contract-selftest.sh
@@ -46,15 +46,21 @@ CACHE="grpcs://gf-reapi-cell.internal:443"
 echo "== happy paths (exit 0) =="
 # Current kit/bridge shape: cache attaches, declared shared-cache-backed, cluster runner.
 run_case 0 "shared-cache attaches on cluster runner, declared shared-cache-backed" \
-  BAZEL_REMOTE_CACHE="${CACHE}" GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed GF_BAZEL_RUNNER_LABELS=tinyland-nix
+  BAZEL_REMOTE_CACHE="${CACHE}" GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed \
+  GF_FLYWHEEL_PROFILE_STATE=shared-cache-backed GF_BAZEL_RUNNER_LABELS=tinyland-nix
 # Back-compat: no runner labels supplied (pre-TIN-2109 callers).
 run_case 0 "shared-cache attaches, no runner labels supplied (back-compat)" \
   BAZEL_REMOTE_CACHE="${CACHE}" GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed
 # Full executor contract present => executor-backed classification passes.
 run_case 0 "executor-backed full contract present" \
   BAZEL_REMOTE_EXECUTOR="${CACHE}" BAZEL_REMOTE_CACHE="${CACHE}" \
-  GF_BAZEL_RUNNER_LABELS=tinyland-nix GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST=sha256:deadbeef \
+  GF_FLYWHEEL_PROFILE_STATE=executor-backed GF_BAZEL_RUNNER_LABELS=tinyland-nix \
+  GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST=sha256:deadbeef \
   GF_BAZEL_SUBSTRATE_MODE=executor-backed
+run_case 0 "local-proof allows localhost only with explicit proof marker" \
+  BAZEL_REMOTE_CACHE='grpc://localhost:9092' GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed \
+  GF_FLYWHEEL_PROFILE_STATE=local-proof GF_BAZEL_LOCAL_PROOF=port-forward \
+  GF_BAZEL_ALLOW_LOCALHOST_PROOF=true
 
 echo "== declared-vs-actual mismatch (exit 1) =="
 run_case 1 "declared shared-cache-backed but no cache attaches" \
@@ -88,6 +94,21 @@ run_case 1 "localhost cache without GF_BAZEL_ALLOW_LOCALHOST_PROOF" \
   BAZEL_REMOTE_CACHE='grpc://localhost:9092' GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed
 run_case 1 "strict with empty BAZEL_REMOTE_CACHE (compat declared compat)" \
   GF_BAZEL_SUBSTRATE_MODE=compatibility-local-only
+
+echo "== profile-state mismatch (exit 1) =="
+run_case 1 "profile shared-cache-backed but executor endpoint set" \
+  BAZEL_REMOTE_CACHE="${CACHE}" BAZEL_REMOTE_EXECUTOR="${CACHE}" \
+  GF_BAZEL_SUBSTRATE_MODE=executor-backed GF_FLYWHEEL_PROFILE_STATE=shared-cache-backed \
+  GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST=sha256:deadbeef GF_BAZEL_RUNNER_LABELS=tinyland-nix
+run_case 1 "profile unattached but cache endpoint set" \
+  BAZEL_REMOTE_CACHE="${CACHE}" GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed \
+  GF_FLYWHEEL_PROFILE_STATE=unattached
+run_case 1 "local-proof missing port-forward marker" \
+  BAZEL_REMOTE_CACHE='grpc://localhost:9092' GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed \
+  GF_FLYWHEEL_PROFILE_STATE=local-proof GF_BAZEL_ALLOW_LOCALHOST_PROOF=true
+run_case 1 "unknown profile state" \
+  BAZEL_REMOTE_CACHE="${CACHE}" GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed \
+  GF_FLYWHEEL_PROFILE_STATE=maybe
 
 echo
 echo "cache-attachment-contract self-test: ${pass} passed, ${fail} failed"

--- a/scripts/cache-attachment-contract.sh
+++ b/scripts/cache-attachment-contract.sh
@@ -27,6 +27,7 @@
 #   - executor set without a cache endpoint
 #   - executor != cache unless GF_BAZEL_ALLOW_SEPARATE_EXECUTOR_CACHE=true
 #   - declared GF_BAZEL_SUBSTRATE_MODE disagreeing with endpoint presence
+#   - declared GF_FLYWHEEL_PROFILE_STATE contradicting the selected substrate
 #   - --strict with an empty BAZEL_REMOTE_CACHE
 #   - (TIN-2109) --strict on a hosted / repo-shaped runner: a missing substrate is a
 #     deterministic failure, never a silent degrade to a GitHub-hosted build. Gated by
@@ -55,6 +56,10 @@ Environment:
   BAZEL_REMOTE_EXECUTOR     Optional remote executor endpoint. Classified as
                             executor-backed but NOT selected by the cache-first lane.
   GF_BAZEL_SUBSTRATE_MODE   Optional declared mode; must agree with endpoint presence.
+  GF_FLYWHEEL_PROFILE_STATE Optional fleet enrollment state. Valid values:
+                            unattached, shared-cache-backed, executor-backed,
+                            local-proof. When set, it must agree with the
+                            selected cache/executor environment.
   GF_BAZEL_ALLOW_LOCALHOST_PROOF
                             Set true to permit a localhost endpoint (explicit proof only).
   GF_BAZEL_ALLOW_SEPARATE_EXECUTOR_CACHE
@@ -95,6 +100,7 @@ done
 remote_cache="${BAZEL_REMOTE_CACHE:-}"
 remote_executor="${BAZEL_REMOTE_EXECUTOR:-}"
 mode="${GF_BAZEL_SUBSTRATE_MODE:-}"
+profile_state="${GF_FLYWHEEL_PROFILE_STATE:-}"
 
 if [[ -n ${remote_executor} ]]; then
   expected_mode="executor-backed"
@@ -221,6 +227,7 @@ Bazel mode:         ${effective_mode}
 Bazel remote cache: ${remote_cache:-unset}
 Bazel executor:     ${remote_executor:-unset}
 Expected mode:      ${expected_mode}
+Flywheel profile:   ${profile_state:-unset}
 Runner class:       ${runner_class:-${runner_labels_raw:+unclassified (${runner_labels_raw})}}
 Strict:             ${STRICT}
 
@@ -239,6 +246,51 @@ if [[ ${effective_mode} != "${expected_mode}" ]]; then
   echo "ERROR: GF_BAZEL_SUBSTRATE_MODE=${effective_mode} disagrees with endpoint presence (expected ${expected_mode})."
   exit 1
 fi
+
+case "${profile_state}" in
+"") ;;
+unattached)
+  if [[ -n ${remote_cache} || -n ${remote_executor} || ${effective_mode} != "compatibility-local-only" ]]; then
+    echo
+    echo "ERROR: GF_FLYWHEEL_PROFILE_STATE=unattached must not set cache/executor endpoints or a cache-backed mode."
+    exit 1
+  fi
+  ;;
+shared-cache-backed)
+  if [[ ${effective_mode} != "shared-cache-backed" || -z ${remote_cache} || -n ${remote_executor} ]]; then
+    echo
+    echo "ERROR: GF_FLYWHEEL_PROFILE_STATE=shared-cache-backed requires GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed, BAZEL_REMOTE_CACHE, and no BAZEL_REMOTE_EXECUTOR."
+    exit 1
+  fi
+  ;;
+executor-backed)
+  if [[ ${effective_mode} != "executor-backed" || -z ${remote_cache} || -z ${remote_executor} ]]; then
+    echo
+    echo "ERROR: GF_FLYWHEEL_PROFILE_STATE=executor-backed requires GF_BAZEL_SUBSTRATE_MODE=executor-backed plus cache and executor endpoints."
+    exit 1
+  fi
+  ;;
+local-proof)
+  if [[ ${GF_BAZEL_LOCAL_PROOF:-} != "port-forward" ]]; then
+    echo
+    echo "ERROR: GF_FLYWHEEL_PROFILE_STATE=local-proof requires GF_BAZEL_LOCAL_PROOF=port-forward."
+    exit 1
+  fi
+  case "${effective_mode}" in
+  shared-cache-backed | executor-backed) ;;
+  *)
+    echo
+    echo "ERROR: GF_FLYWHEEL_PROFILE_STATE=local-proof requires shared-cache-backed or executor-backed substrate mode."
+    exit 1
+    ;;
+  esac
+  ;;
+*)
+  echo
+  echo "ERROR: GF_FLYWHEEL_PROFILE_STATE=${profile_state} is not recognized. Expected unattached, shared-cache-backed, executor-backed, or local-proof."
+  exit 1
+  ;;
+esac
 
 if [[ ${literal_cache} == "true" ]]; then
   echo

--- a/scripts/validate-ci-templates.py
+++ b/scripts/validate-ci-templates.py
@@ -234,6 +234,7 @@ def check_cache_backed_optin_contract() -> int:
         # TIN-2109: expected mode is manifest-driven (enrollment.substrateMode)
         ".enrollment.substrateMode",
         "GF_BAZEL_SUBSTRATE_MODE=",
+        "GF_FLYWHEEL_PROFILE_STATE=",
         # TIN-2109: runner labels fed so the contract rejects hosted/repo-label fallback
         "GF_BAZEL_RUNNER_LABELS=",
         "join(runner.labels, ',')",
@@ -289,6 +290,7 @@ def check_cache_backed_optin_contract() -> int:
         "GF_BAZEL_ALLOW_HOSTED_RUNNER",
         "classify_runner",
         # executor-backed contract: full required set, defined + enforced
+        "GF_FLYWHEEL_PROFILE_STATE",
         "GF_BAZEL_REAPI_PROOF_IMAGE_DIGEST",
         'executor-backed mode requires BAZEL_REMOTE_CACHE',
     ]


### PR DESCRIPTION
## Summary
- export `GF_FLYWHEEL_PROFILE_STATE` from cache-backed reusable workflow lanes after resolving manifest-driven substrate mode
- teach the cache attachment contract to reject contradictory profile states
- document that profile state is machine-readable attachment state, not a secret or token authority

## Boundaries
- cache-backed lanes remain cache-first and do not wire remote executor
- does not mint tokens or enforce auth at the cache front door
- does not introduce repo-specific runner labels or hosted-runner fallback

## Validation
- `just cache-contract-selftest`
- `just cache-backed-optin-contract-check`
- `nix develop --command just check`

TIN-2130